### PR TITLE
Add simple attribute completions for all tags and many attribute values on the HTMX reference

### DIFF
--- a/lsp/src/htmx/attributes/hx-boost.md
+++ b/lsp/src/htmx/attributes/hx-boost.md
@@ -28,3 +28,4 @@ All requests are done via AJAX, so keep that in mind when doing things like redi
 To find out if the request results from a boosted anchor or form, look for HX-Boosted in the request header
 Selectively disable boost on child elements with hx-boost="false"
 
+[HTMX Reference](https://htmx.org/attributes/hx-boost/)

--- a/lsp/src/htmx/attributes/hx-confirm.md
+++ b/lsp/src/htmx/attributes/hx-confirm.md
@@ -1,0 +1,14 @@
+The hx-confirm attribute allows you to confirm an action before issuing a request. This can be useful in cases where the action is destructive and you want to ensure that the user really wants to do it.
+
+Here is an example:
+
+<button hx-delete="/account" hx-confirm="Are you sure you wish to delete your account?">
+  Delete My Account
+</button>
+
+Notes
+
+    hx-confirm is inherited and can be placed on a parent element
+
+[HTMX Reference](https://htmx.org/attributes/hx-confirm/)
+

--- a/lsp/src/htmx/attributes/hx-delete.md
+++ b/lsp/src/htmx/attributes/hx-delete.md
@@ -14,3 +14,5 @@ You can control the swap strategy by using the hx-swap attribute
 You can control what event triggers the request with the hx-trigger attribute
 You can control the data submitted with the request in various ways, documented here: Parameters
 To remove the element following a successful DELETE, return a 200 status code with an empty body; if the server responds with a 204, no swap takes place, documented here: Requests & Responses
+
+[HTMX Reference](https://htmx.org/attributes/hx-delete/)

--- a/lsp/src/htmx/attributes/hx-disable.md
+++ b/lsp/src/htmx/attributes/hx-disable.md
@@ -1,0 +1,9 @@
+The hx-disable attribute will disable htmx processing for a given element and all its children. This can be useful as a backup for HTML escaping, when you include user generated content in your site, and you want to prevent malicious scripting attacks.
+
+The value of the tag is ignored, and it cannot be reversed by any content beneath it.
+Notes
+
+    hx-disable is inherited
+
+[HTMX Reference](https://htmx.org/attributes/hx-disable/)
+

--- a/lsp/src/htmx/attributes/hx-encoding.md
+++ b/lsp/src/htmx/attributes/hx-encoding.md
@@ -1,0 +1,11 @@
+The hx-encoding attribute allows you to switch the request encoding from the usual application/x-www-form-urlencoded encoding to multipart/form-data, usually to support file uploads in an ajax request.
+
+The value of this attribute should be multipart/form-data.
+
+The hx-encoding tag may be placed on parent elements.
+Notes
+
+    hx-encoding is inherited and can be placed on a parent element
+
+[HTMX Reference](https://htmx.org/attributes/hx-encoding/)
+

--- a/lsp/src/htmx/attributes/hx-ext.md
+++ b/lsp/src/htmx/attributes/hx-ext.md
@@ -1,0 +1,8 @@
+reference an extension
+
+Tip: To use multiple extensions on one element, seperate them with a comma:
+  <button hx-post="/example" hx-ext="debug, json-enc">This Button Uses Two Extensions</button>
+
+by default, extensions are applied to the DOM node where it is invoked, along with all child elements inside of that parent node. If you need to disable an extension somewhere within the DOM tree, you can use the ignore: keyword to stop it from being used.
+
+

--- a/lsp/src/htmx/attributes/hx-ext.md
+++ b/lsp/src/htmx/attributes/hx-ext.md
@@ -6,3 +6,4 @@ Tip: To use multiple extensions on one element, seperate them with a comma:
 by default, extensions are applied to the DOM node where it is invoked, along with all child elements inside of that parent node. If you need to disable an extension somewhere within the DOM tree, you can use the ignore: keyword to stop it from being used.
 
 
+[HTMX Reference](https://htmx.org/attributes/hx-ext/)

--- a/lsp/src/htmx/attributes/hx-get.md
+++ b/lsp/src/htmx/attributes/hx-get.md
@@ -13,3 +13,5 @@ You can control the swap strategy by using the hx-swap attribute
 You can control what event triggers the request with the hx-trigger attribute
 You can control the data submitted with the request in various ways, documented here: Parameters
 
+
+[HTMX Reference](https://htmx.org/attributes/hx-get/)

--- a/lsp/src/htmx/attributes/hx-headers.md
+++ b/lsp/src/htmx/attributes/hx-headers.md
@@ -1,0 +1,19 @@
+The hx-headers attribute allows you to add to the headers that will be submitted with an AJAX request.
+
+By default, the value of this attribute is a list of name-expression values in JSON (JavaScript Object Notation) format.
+
+If you wish for hx-headers to evaluate the values given, you can prefix the values with javascript: or js:.
+
+  <div hx-get="/example" hx-headers='{"myHeader": "My Value"}'>Get Some HTML, Including A Custom Header in the Request</div>
+
+Security Considerations
+
+    By default, the value of hx-headers must be valid JSON. It is not dynamically computed. If you use the javascript: prefix, be aware that you are introducing security considerations, especially when dealing with user input such as query strings or user-generated content, which could introduce a Cross-Site Scripting (XSS) vulnerability.
+
+Notes
+
+    hx-headers is inherited and can be placed on a parent element.
+    A child declaration of a header overrides a parent declaration.
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-headers/)

--- a/lsp/src/htmx/attributes/hx-history-elt.md
+++ b/lsp/src/htmx/attributes/hx-history-elt.md
@@ -3,11 +3,11 @@ The hx-history-elt attribute allows you to specify the element that will be used
 Here is an example:
 
 <html>
-<body>
-<div id="content" hx-history-elt>
- ...
-</div>
-</body>
+  <body>
+    <div id="content" hx-history-elt>
+     ...
+    </div>
+  </body>
 </html>
 
 Notes

--- a/lsp/src/htmx/attributes/hx-history-elt.md
+++ b/lsp/src/htmx/attributes/hx-history-elt.md
@@ -1,0 +1,19 @@
+The hx-history-elt attribute allows you to specify the element that will be used to snapshot and restore page state during navigation. By default, the body tag is used. This is typically good enough for most setups, but you may want to narrow it down to a child element. Just make sure that the element is always visible in your application, or htmx will not be able to restore history navigation properly.
+
+Here is an example:
+
+<html>
+<body>
+<div id="content" hx-history-elt>
+ ...
+</div>
+</body>
+</html>
+
+Notes
+
+    hx-history-elt is not inherited
+    In most cases we don’t recommend narrowing the history snapshot
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-history-elt/)

--- a/lsp/src/htmx/attributes/hx-history.md
+++ b/lsp/src/htmx/attributes/hx-history.md
@@ -5,11 +5,11 @@ History navigation will work as expected, but on restoration the URL will be req
 Here is an example:
 
 <html>
-<body>
-<div hx-history="false">
- ...
-</div>
-</body>
+  <body>
+    <div hx-history="false">
+     ...
+    </div>
+  </body>
 </html>
 
 Notes

--- a/lsp/src/htmx/attributes/hx-history.md
+++ b/lsp/src/htmx/attributes/hx-history.md
@@ -1,0 +1,20 @@
+Set the hx-history attribute to false on any element in the current document, or any html fragment loaded into the current document by htmx, to prevent sensitive data being saved to the localStorage cache when htmx takes a snapshot of the page state.
+
+History navigation will work as expected, but on restoration the URL will be requested from the server instead of the history cache.
+
+Here is an example:
+
+<html>
+<body>
+<div hx-history="false">
+ ...
+</div>
+</body>
+</html>
+
+Notes
+
+    hx-history="false" can be present anywhere in the document to embargo the current page state from the history cache (i.e. even outside the element specified for the history snapshot hx-history-elt).
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-history/)

--- a/lsp/src/htmx/attributes/hx-include.md
+++ b/lsp/src/htmx/attributes/hx-include.md
@@ -17,3 +17,4 @@ Note that if you include a non-input element, all input elements enclosed in tha
 Notes
 hx-include is inherited and can be placed on a parent element
 
+[HTMX Reference](https://htmx.org/attributes/hx-include/)

--- a/lsp/src/htmx/attributes/hx-include.md
+++ b/lsp/src/htmx/attributes/hx-include.md
@@ -18,3 +18,4 @@ Notes
 hx-include is inherited and can be placed on a parent element
 
 [HTMX Reference](https://htmx.org/attributes/hx-include/)
+

--- a/lsp/src/htmx/attributes/hx-indicator.md
+++ b/lsp/src/htmx/attributes/hx-indicator.md
@@ -1,0 +1,57 @@
+The hx-indicator attribute allows you to specify the element that will have the htmx-request class added to it for the duration of the request. This can be used to show spinners or progress indicators while the request is in flight.
+
+The value of this attribute is a CSS query selector of the element or elements to apply the class to, or the keyword closest, followed by a CSS selector, which will find the closest ancestor element or itself, that matches the given CSS selector (e.g. closest tr);
+
+Here is an example with a spinner adjacent to the button:
+
+<div>
+    <button hx-post="/example" hx-indicator="#spinner">
+        Post It!
+    </button>
+    <img  id="spinner" class="htmx-indicator" src="/img/bars.svg"/>
+</div>
+
+When a request is in flight, this will cause the htmx-request class to be added to the #spinner image. The image also has the htmx-indicator class on it, which defines an opacity transition that will show the spinner:
+
+    .htmx-indicator{
+        opacity:0;
+        transition: opacity 500ms ease-in;
+    }
+    .htmx-request .htmx-indicator{
+        opacity:1
+    }
+    .htmx-request.htmx-indicator{
+        opacity:1
+    }
+
+If you would prefer a different effect for showing the spinner you could define and use your own indicator CSS. Here is an example that uses display rather than opacity (Note that we use my-indicator instead of htmx-indicator):
+
+    .my-indicator{
+        display:none;
+    }
+    .htmx-request .my-indicator{
+        display:inline;
+    }
+    .htmx-request.my-indicator{
+        display:inline;
+    }
+
+Note that the target of the hx-indicator selector need not be the exact element that you want to show: it can be any element in the parent hierarchy of the indicator.
+
+Finally, note that the htmx-request class by default is added to the element causing the request, so you can place an indicator inside of that element and not need to explicitly call it out with the hx-indicator attribute:
+
+<button hx-post="/example">
+    Post It!
+   <img  class="htmx-indicator" src="/img/bars.svg"/>
+</button>
+
+Notes
+
+    hx-indicator is inherited and can be placed on a parent element
+    In the absence of an explicit indicator, the htmx-request class will be added to the element triggering the request
+    If you want to use your own CSS but still use htmx-indicator as class name, then you need to disable includeIndicatorStyles. See Configuring htmx. The easiest way is to add this the <head> of your HTML:
+
+<meta name="htmx-config" content='{"includeIndicatorStyles": false}'>
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-indicator/)

--- a/lsp/src/htmx/attributes/hx-on.md
+++ b/lsp/src/htmx/attributes/hx-on.md
@@ -1,0 +1,45 @@
+The hx-on attribute allows you to embed scripts inline to respond to events directly on an element; similar to the onevent properties found in HTML, such as onClick.
+
+hx-on improves upon onevent by enabling the handling of any event for enhanced Locality of Behaviour (LoB). This also enables you to handle any htmx event.
+
+There are two forms of this attribute, one in which you specify the event as part of the attribute name after a colon (hx-on:click, for example), and a deprecated form that uses the hx-on attribute directly. The latter should only be used if IE11 support is required.
+hx-on:* (recommended)
+
+The event name follows a colon : in the attribute, and the attribute value is the script to be executed:
+
+<div hx-on:click="alert('Clicked!')">Click</div>
+
+All htmx events can be captured, too! Make sure to use the kebab-case event name, because DOM attributes do not preserve casing. For instance, hx-on::beforeRequest will not work: use hx-on::before-request instead.
+
+To make writing these a little easier, you can use the shorthand double-colon hx-on:: for htmx events, and omit the “htmx” part:
+
+<!-- These two are equivalent -->
+<button hx-get="/info" hx-on:htmx:before-request="alert('Making a request!')">
+    Get Info!
+</button>
+
+<button hx-get="/info" hx-on::before-request="alert('Making a request!')">
+    Get Info!
+</button>
+
+Adding multiple handlers is easy, you just specify additional attributes:
+
+<button hx-get="/info"
+        hx-on::before-request="alert('Making a request!')"
+        hx-on::after-request="alert('Done making a request!')">
+    Get Info!
+</button>
+
+Symbols
+
+Like onevent, two symbols are made available to event handler scripts:
+
+    this - The element on which the hx-on attribute is defined
+    event - The event that triggered the handler
+
+Notes
+
+    hx-on is not inherited, however due to event bubbling, hx-on attributes on parent elements will typically be triggered by events on child elements
+    hx-on:* and hx-on cannot be used together on the same element; if hx-on:* is present, the value of an hx-on attribute on the same element will be ignored. The two forms can be mixed in the same document, however.
+
+[HTMX Reference](https://htmx.org/attributes/hx-on/)

--- a/lsp/src/htmx/attributes/hx-params.md
+++ b/lsp/src/htmx/attributes/hx-params.md
@@ -1,0 +1,18 @@
+The hx-params attribute allows you to filter the parameters that will be submitted with an AJAX request.
+
+The possible values of this attribute are:
+
+    * - Include all parameters (default)
+    none - Include no parameters
+    not <param-list> - Include all except the comma separated list of parameter names
+    <param-list> - Include all the comma separated list of parameter names
+
+  <div hx-get="/example" hx-params="*">Get Some HTML, Including Params</div>
+
+This div will include all the parameters that a POST would, but they will be URL encoded and included in the URL, as per usual with a GET.
+Notes
+
+    hx-params is inherited and can be placed on a parent element
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-params/)

--- a/lsp/src/htmx/attributes/hx-patch.md
+++ b/lsp/src/htmx/attributes/hx-patch.md
@@ -13,3 +13,5 @@ You can control the target of the swap using the hx-target attribute
 You can control the swap strategy by using the hx-swap attribute
 You can control what event triggers the request with the hx-trigger attribute
 You can control the data submitted with the request in various ways, documented here: Parameters
+
+[HTMX Reference](https://htmx.org/attributes/hx-patch/)

--- a/lsp/src/htmx/attributes/hx-post.md
+++ b/lsp/src/htmx/attributes/hx-post.md
@@ -14,3 +14,4 @@ You can control the swap strategy by using the hx-swap attribute
 You can control what event triggers the request with the hx-trigger attribute
 You can control the data submitted with the request in various ways, documented here: Parameters
 
+[HTMX Reference](https://htmx.org/attributes/hx-post/)

--- a/lsp/src/htmx/attributes/hx-preserve.md
+++ b/lsp/src/htmx/attributes/hx-preserve.md
@@ -1,0 +1,9 @@
+The hx-preserve attribute allows you to keep an element unchanged during HTML replacement. Elements with hx-preserve set are preserved by id when htmx updates any ancestor element. You must set an unchanging id on elements for hx-preserve to work. The response requires an element with the same id, but its type and other attributes are ignored.
+
+Note that some elements cannot unfortunately be preserved properly, such as <input type="text"> (focus and caret position are lost), iframes or certain types of videos. To tackle some of these cases we recommend the morphdom extension, which does a more elaborate DOM reconciliation.
+Notes
+
+    hx-preserve is not inherited
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-preserve/)

--- a/lsp/src/htmx/attributes/hx-prompt.md
+++ b/lsp/src/htmx/attributes/hx-prompt.md
@@ -1,0 +1,14 @@
+The hx-prompt attribute allows you to show a prompt before issuing a request. The value of the prompt will be included in the request in the HX-Prompt header.
+
+Here is an example:
+
+<button hx-delete="/account" hx-prompt="Enter your account name to confirm deletion">
+  Delete My Account
+</button>
+
+Notes
+
+    hx-prompt is inherited and can be placed on a parent element
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-prompt/)

--- a/lsp/src/htmx/attributes/hx-push-url.md
+++ b/lsp/src/htmx/attributes/hx-push-url.md
@@ -29,3 +29,4 @@ Notes
     The HX-Push-Url response header has similar behavior and can override this attribute.
     The hx-history-elt attribute allows changing which element is saved in the history cache.
 
+[HTMX Reference](https://htmx.org/attributes/hx-push-url/)

--- a/lsp/src/htmx/attributes/hx-put.md
+++ b/lsp/src/htmx/attributes/hx-put.md
@@ -14,3 +14,4 @@ You can control the swap strategy by using the hx-swap attribute
 You can control what event triggers the request with the hx-trigger attribute
 You can control the data submitted with the request in various ways, documented here: Parameters
 
+[HTMX Reference](https://htmx.org/attributes/hx-put/)

--- a/lsp/src/htmx/attributes/hx-replace-url.md
+++ b/lsp/src/htmx/attributes/hx-replace-url.md
@@ -1,0 +1,32 @@
+The hx-replace-url attribute allows you to replace the current url of the browser location history.
+
+The possible values of this attribute are:
+
+    true, which replaces the fetched URL in the browser navigation bar.
+    false, which disables replacing the fetched URL if it would otherwise be replaced due to inheritance.
+    A URL to be replaced into the location bar. This may be relative or absolute, as per history.replaceState().
+
+Here is an example:
+
+<div hx-get="/account" hx-replace-url="true">
+  Go to My Account
+</div>
+
+This will cause htmx to snapshot the current DOM to localStorage and replace the URL `/account’ in the browser location bar.
+
+Another example:
+
+<div hx-get="/account" hx-replace-url="/account/home">
+  Go to My Account
+</div>
+
+This will replace the URL `/account/home’ in the browser location bar.
+Notes
+
+    hx-replace-url is inherited and can be placed on a parent element
+    The HX-Replace-Url response header has similar behavior and can override this attribute.
+    The hx-history-elt attribute allows changing which element is saved in the history cache.
+    The hx-push-url attribute is a similar and more commonly used attribute, which creates a new history entry rather than replacing the current one.
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-replace-url/)

--- a/lsp/src/htmx/attributes/hx-request.md
+++ b/lsp/src/htmx/attributes/hx-request.md
@@ -1,0 +1,24 @@
+The hx-request attribute allows you to configure various aspects of the request via the following attributes:
+
+    timeout - the timeout for the request, in milliseconds
+    credentials - if the request will send credentials
+    noHeaders - strips all headers from the request
+
+These attributes are set using a JSON-like syntax:
+
+<div ... hx-request='\"timeout\":100'>
+  ...
+</div>
+
+You may make the values dynamically evaluated by adding the javascript: or js: prefix:
+
+<div ... hx-request='js: timeout:getTimeoutSetting() '>
+  ...
+</div>
+
+Notes
+
+    hx-request is merge-inherited and can be placed on a parent element
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-request/)

--- a/lsp/src/htmx/attributes/hx-select-oob.md
+++ b/lsp/src/htmx/attributes/hx-select-oob.md
@@ -1,0 +1,36 @@
+The hx-select-oob attribute allows you to select content from a response to be swapped in via an out-of-band swap.
+The value of this attribute is comma separated list of elements to be swapped out of band. This attribute is almost always paired with hx-select.
+
+Here is an example that selects a subset of the response content:
+
+<div>
+   <div id="alert"></div>
+    <button hx-get="/info"
+            hx-select="#info-details"
+            hx-swap="outerHTML"
+            hx-select-oob="#alert">
+        Get Info!
+    </button>
+</div>
+
+This button will issue a GET to /info and then select the element with the id info-details, which will replace the entire button in the DOM, and, in addition, pick out an element with the id alert in the response and swap it in for div in the DOM with the same ID.
+
+Each value in the comma separated list of values can specify any valid hx-swap strategy by separating the selector and the swap strategy with a :.
+
+For example, to prepend the alert content instead of replacing it:
+
+<div>
+   <div id="alert"></div>
+    <button hx-get="/info"
+            hx-select="#info-details"
+            hx-swap="outerHTML"
+            hx-select-oob="#alert:afterbegin">
+        Get Info!
+    </button>
+</div>
+
+Notes
+
+    hx-select-oob is inherited and can be placed on a parent element
+
+[HTMX Reference](https://htmx.org/attributes/hx-select-oob/)

--- a/lsp/src/htmx/attributes/hx-select.md
+++ b/lsp/src/htmx/attributes/hx-select.md
@@ -17,3 +17,4 @@ Notes
 
 
 
+[HTMX Reference](https://htmx.org/attributes/hx-select/)

--- a/lsp/src/htmx/attributes/hx-swap-oob.md
+++ b/lsp/src/htmx/attributes/hx-swap-oob.md
@@ -1,0 +1,30 @@
+The hx-swap-oob attribute allows you to specify that some content in a response should be swapped into the DOM somewhere other than the target, that is “Out of Band”. This allows you to piggy back updates to other element updates on a response.
+
+Consider the following response HTML:
+
+<div>
+ ...
+</div>
+<div id="alerts" hx-swap-oob="true">
+    Saved!
+</div>
+
+The first div will be swapped into the target the usual manner. The second div, however, will be swapped in as a replacement for the element with the id alerts, and will not end up in the target.
+
+The value of the hx-swap-oob can be:
+
+    true
+    any valid hx-swap value
+    any valid hx-swap value, followed by a colon, followed by a CSS selector
+
+If the value is true or outerHTML (which are equivalent) the element will be swapped inline.
+
+If a swap value is given, that swap strategy will be used.
+
+If a selector is given, all elements matched by that selector will be swapped. If not, the element with an ID matching the new content will be swapped.
+Notes
+
+    hx-swap-oob is not inherited
+    Out of band elements must be in the top level of the response, and not children of the top level elements.
+
+[HTMX Reference](https://htmx.org/attributes/hx-swap-oob/)

--- a/lsp/src/htmx/attributes/hx-swap.md
+++ b/lsp/src/htmx/attributes/hx-swap.md
@@ -84,3 +84,4 @@ Due to DOM limitations, it’s not possible to use the outerHTML method on the <
 The default swap delay is 0ms
 The default settle delay is 20ms
 
+[HTMX Reference](https://htmx.org/attributes/hx-swap/)

--- a/lsp/src/htmx/attributes/hx-sync.md
+++ b/lsp/src/htmx/attributes/hx-sync.md
@@ -1,0 +1,57 @@
+The hx-sync attribute allows you to synchronize AJAX requests between multiple elements.
+
+The hx-sync attribute consists of a CSS selector to indicate the element to synchronize on, followed optionally by a colon and then by an optional syncing strategy. The available strategies are:
+
+    drop - drop (ignore) this request if an existing request is in flight (the default)
+    abort - drop (ignore) this request if an existing request is in flight, and, if that is not the case, abort this request if another request occurs while it is still in flight
+    replace - abort the current request, if any, and replace it with this request
+    queue - place this request in the request queue associated with the given element
+
+The queue modifier can take an additional argument indicating exactly how to queue:
+
+    queue first - queue the first request to show up while a request is in flight
+    queue last - queue the last request to show up while a request is in flight
+    queue all - queue all requests that show up while a request is in flight
+
+Notes
+
+    hx-sync is inherited and can be placed on a parent element
+
+This example resolves a race condition between a form’s submit request and an individual input’s validation request. Normally, without using hx-sync, filling out the input and immediately submitting the form triggers two parallel requests to /validate and /store. Using hx-sync="closest form:abort" on the input will watch for requests on the form and abort the input’s request if a form request is present or starts while the input request is in flight.
+
+<form hx-post="/store">
+    <input id="title" name="title" type="text"
+        hx-post="/validate"
+        hx-trigger="change"
+        hx-sync="closest form:abort">
+    <button type="submit">Submit</button>
+</form>
+
+If you’d rather prioritize the validation request over the submit request, you can use the drop strategy. This example will prioritize the validation request over the submit request so that if a validation request is in flight, the form cannot be submitted.
+
+<form hx-post="/store">
+    <input id="title" name="title" type="text"
+        hx-post="/validate"
+        hx-trigger="change"
+        hx-sync="closest form:drop"
+    >
+    <button type="submit">Submit</button>
+</form>
+
+When dealing with forms that contain many inputs, you can prioritize the submit request over all input validation requests using the hx-sync replace strategy on the form tag. This will cancel any in-flight validation requests and issue only the hx-post="/store" request. If you’d rather abort the submit request and prioritize any existing validation requests you can use the hx-sync="this:abort" strategy on the form tag.
+
+<form hx-post="/store" hx-sync="this:replace">
+    <input id="title" name="title" type="text" hx-post="/validate" hx-trigger="change" />
+    <button type="submit">Submit</button>
+</form>
+
+When implementing active search functionality the hx-trigger attribute’s delay modifier can be used to debounce the user’s input and avoid making multiple requests while the user types. However, once a request is made, if the user begins typing again a new request will begin even if the previous one has not finished processing. This example will cancel any in-flight requests and use only the last request. In cases where the search input is contained within the target, then using hx-sync like this also helps reduce the chances that the input will be replaced while the user is still typing.
+
+<input type="search"
+    hx-get="/search"
+    hx-trigger="keyup changed delay:500ms, search"
+    hx-target="#search-results"
+    hx-sync="this:replace">
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-sync/)

--- a/lsp/src/htmx/attributes/hx-target.md
+++ b/lsp/src/htmx/attributes/hx-target.md
@@ -23,3 +23,5 @@ This example uses hx-target="this" to make a link that updates itself when click
 <a hx-post="/new-link" hx-target="this" hx-swap="outerHTML">New link</a>
 Notes
 hx-target is inherited and can be placed on a parent element
+
+[HTMX Reference](https://htmx.org/attributes/hx-target/)

--- a/lsp/src/htmx/attributes/hx-trigger.md
+++ b/lsp/src/htmx/attributes/hx-trigger.md
@@ -94,3 +94,5 @@ The AJAX request can be triggered via JavaScript htmx.trigger(), too.
 Notes
 hx-trigger is not inherited
 hx-trigger can be used without an AJAX request, in which case it will only fire the htmx:trigger event
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/attributes/hx-validate.md
+++ b/lsp/src/htmx/attributes/hx-validate.md
@@ -1,0 +1,9 @@
+The hx-validate attribute will cause an element to validate itself by way of the HTML5 Validation API before it submits a request.
+
+Form elements do this by default, but other elements do not.
+Notes
+
+    hx-validate is not inherited
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-validate/)

--- a/lsp/src/htmx/attributes/hx-vals.md
+++ b/lsp/src/htmx/attributes/hx-vals.md
@@ -20,3 +20,5 @@ Notes
 hx-vals is inherited and can be placed on a parent element.
 A child declaration of a variable overrides a parent declaration.
 Input values with the same name will be overridden by variable declarations.
+
+[HTMX Reference](https://htmx.org/attributes/hx-vals/)

--- a/lsp/src/htmx/hx-boost/false.md
+++ b/lsp/src/htmx/hx-boost/false.md
@@ -1,0 +1,1 @@
+Selectively disable boost on this element and child elements

--- a/lsp/src/htmx/hx-boost/false.md
+++ b/lsp/src/htmx/hx-boost/false.md
@@ -1,1 +1,3 @@
 Selectively disable boost on this element and child elements
+
+[HTMX Reference](https://htmx.org/attributes/hx-boost/)

--- a/lsp/src/htmx/hx-boost/true.md
+++ b/lsp/src/htmx/hx-boost/true.md
@@ -1,0 +1,7 @@
+The hx-boost attribute allows you to “boost” normal anchors and form tags to use AJAX instead. This has the nice fallback that, if the user does not have javascript enabled, the site will continue to work.
+
+Notes
+hx-boost is inherited and can be placed on a parent element
+Only links that are to the same domain and that are not local anchors will be boosted
+All requests are done via AJAX, so keep that in mind when doing things like redirects
+To find out if the request results from a boosted anchor or form, look for HX-Boosted in the request header

--- a/lsp/src/htmx/hx-boost/true.md
+++ b/lsp/src/htmx/hx-boost/true.md
@@ -5,3 +5,5 @@ hx-boost is inherited and can be placed on a parent element
 Only links that are to the same domain and that are not local anchors will be boosted
 All requests are done via AJAX, so keep that in mind when doing things like redirects
 To find out if the request results from a boosted anchor or form, look for HX-Boosted in the request header
+
+[HTMX Reference](https://htmx.org/attributes/hx-boost/)

--- a/lsp/src/htmx/hx-ext/ajax-header.md
+++ b/lsp/src/htmx/hx-ext/ajax-header.md
@@ -1,0 +1,10 @@
+This extension adds the X-Requested-With header to requests with the value “XMLHttpRequest”.
+This header is commonly used by javascript frameworks to differentiate ajax requests from normal http requests.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/ajax-header.js"></script>
+
+Usage
+<body hx-ext="ajax-header">
+ ...
+</body>

--- a/lsp/src/htmx/hx-ext/ajax-header.md
+++ b/lsp/src/htmx/hx-ext/ajax-header.md
@@ -8,3 +8,6 @@ Usage
 <body hx-ext="ajax-header">
  ...
 </body>
+
+
+[HTMX Reference](https://htmx.org/extensions/ajax-header/)

--- a/lsp/src/htmx/hx-ext/ajax-header.md
+++ b/lsp/src/htmx/hx-ext/ajax-header.md
@@ -6,7 +6,7 @@ Install
 
 Usage
 <body hx-ext="ajax-header">
- ...
+    ...
 </body>
 
 

--- a/lsp/src/htmx/hx-ext/alpine-morph.md
+++ b/lsp/src/htmx/hx-ext/alpine-morph.md
@@ -14,18 +14,18 @@ Usage
 </header>
 
 <body>
-  <div hx-target="this" hx-ext="alpine-morph" hx-swap="morph">
-      <div x-data="{ count: 0, replaced: false,
+    <div hx-target="this" hx-ext="alpine-morph" hx-swap="morph">
+        <div x-data="{ count: 0, replaced: false,
                      message: 'Change me, then press the button!' }">
-          <input type="text" x-model="message">
-          <div x-text="count"></div>
-          <button x-bind:style="replaced && {'backgroundColor': '#fecaca'}"
+            <input type="text" x-model="message">
+            <div x-text="count"></div>
+            <button x-bind:style="replaced && {'backgroundColor': '#fecaca'}"
                   x-on:click="replaced = true; count++"
                   hx-get="/swap">
             Morph
-          </button>
-      </div>
-  </div>
+            </button>
+        </div>
+    </div>
 </body>
 
 In the above example, all the Alpine x-data states (count, replaced, and message) are preserved even the entire Alpine component is swapped.

--- a/lsp/src/htmx/hx-ext/alpine-morph.md
+++ b/lsp/src/htmx/hx-ext/alpine-morph.md
@@ -31,3 +31,6 @@ Usage
 In the above example, all the Alpine x-data states (count, replaced, and message) are preserved even the entire Alpine component is swapped.
 
 NOTE: /swap response from the example above should return actual element that is being replaced (this is <div hx-target="this"... element).
+
+
+[HTMX Reference](https://htmx.org/extensions/alpine-morph/)

--- a/lsp/src/htmx/hx-ext/alpine-morph.md
+++ b/lsp/src/htmx/hx-ext/alpine-morph.md
@@ -1,0 +1,33 @@
+Alpine.js now has a lightweight morph plugin and this extension allows you to use it as the swapping mechanism in htmx which is necessary to retain Alpine state when you have entire Alpine components swapped by htmx.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/alpine-morph.js"></script>
+
+Usage
+<header>
+  <script src="https://unpkg.com/htmx.org@latest"></script>
+  <script src="https://unpkg.com/htmx.org@latest/dist/ext/alpine-morph.js"></script>
+  <!-- Alpine Plugins -->
+  <script defer src="https://unpkg.com/@alpinejs/morph@3.x.x/dist/cdn.min.js"></script>
+  <!-- Alpine Core -->
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</header>
+
+<body>
+  <div hx-target="this" hx-ext="alpine-morph" hx-swap="morph">
+      <div x-data="{ count: 0, replaced: false,
+                     message: 'Change me, then press the button!' }">
+          <input type="text" x-model="message">
+          <div x-text="count"></div>
+          <button x-bind:style="replaced && {'backgroundColor': '#fecaca'}"
+                  x-on:click="replaced = true; count++"
+                  hx-get="/swap">
+            Morph
+          </button>
+      </div>
+  </div>
+</body>
+
+In the above example, all the Alpine x-data states (count, replaced, and message) are preserved even the entire Alpine component is swapped.
+
+NOTE: /swap response from the example above should return actual element that is being replaced (this is <div hx-target="this"... element).

--- a/lsp/src/htmx/hx-ext/class-tools.md
+++ b/lsp/src/htmx/hx-ext/class-tools.md
@@ -21,3 +21,5 @@ Usage
     <div classes="toggle foo:1s"/> <!-- toggles the class "foo" every 1s -->
 </div>
 
+
+[HTMX Reference](https://htmx.org/extensions/class-tools/)

--- a/lsp/src/htmx/hx-ext/class-tools.md
+++ b/lsp/src/htmx/hx-ext/class-tools.md
@@ -1,0 +1,23 @@
+The class-tools extension allows you to specify CSS classes that will be swapped onto or off of the elements by using a classes or data-classes attribute. This functionality allows you to apply CSS Transitions to your HTML without resorting to javascript.
+
+A classes attribute value consists of “runs”, which are separated by an & character. All class operations within a given run will be applied sequentially, with the delay specified.
+
+Within a run, a , character separates distinct class operations.
+
+A class operation is an operation name add, remove, or toggle, followed by a CSS class name, optionally followed by a colon : and a time delay.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/class-tools.js"></script>
+
+Usage
+
+<div hx-ext="class-tools">
+    <div classes="add foo"/> <!-- adds the class "foo" after 100ms -->
+    <div class="bar" classes="remove bar:1s"/> <!-- removes the class "bar" after 1s -->
+    <div class="bar" classes="remove bar:1s, add foo:1s"/> <!-- removes the class "bar" after 1s
+                                                                then adds the class "foo" 1s after that -->
+    <div class="bar" classes="remove bar:1s & add foo:1s"/> <!-- removes the class "bar" and adds
+                                                                 class "foo" after 1s  -->
+    <div classes="toggle foo:1s"/> <!-- toggles the class "foo" every 1s -->
+</div>
+

--- a/lsp/src/htmx/hx-ext/class-tools.md
+++ b/lsp/src/htmx/hx-ext/class-tools.md
@@ -10,7 +10,6 @@ Install
 <script src="https://unpkg.com/htmx.org/dist/ext/class-tools.js"></script>
 
 Usage
-
 <div hx-ext="class-tools">
     <div classes="add foo"/> <!-- adds the class "foo" after 100ms -->
     <div class="bar" classes="remove bar:1s"/> <!-- removes the class "bar" after 1s -->

--- a/lsp/src/htmx/hx-ext/client-side-templates.md
+++ b/lsp/src/htmx/hx-ext/client-side-templates.md
@@ -65,3 +65,4 @@ If you wish to put a template into another file, you can use a directive such as
 </body>
 </html>
 
+[HTMX Reference](https://htmx.org/extensions/client-side-templates/)

--- a/lsp/src/htmx/hx-ext/client-side-templates.md
+++ b/lsp/src/htmx/hx-ext/client-side-templates.md
@@ -17,18 +17,18 @@ Install
 
 Usage
 <div hx-ext="client-side-templates">
-  <button hx-get="/some_json"
+    <button hx-get="/some_json"
           mustache-template="my-mustache-template">
      Handle with mustache
-  </button>
-  <button hx-get="/some_json"
+    </button>
+    <button hx-get="/some_json"
           handlebars-template="my-handlebars-template">
      Handle with handlebars
-  </button>
-  <button hx-get="/some_json"
+    </button>
+    <button hx-get="/some_json"
           nunjucks-template="my-nunjucks-template">
      Handle with nunjucks
-  </button>
+    </button>
 </div>
 
 Full HTML Example

--- a/lsp/src/htmx/hx-ext/client-side-templates.md
+++ b/lsp/src/htmx/hx-ext/client-side-templates.md
@@ -1,0 +1,67 @@
+This extension supports transforming a JSON request response into HTML via a client-side template before it is swapped into the DOM. Currently three client-side templating engines are supported:
+
+    mustache
+    handlebars
+    nunjucks
+
+When you add this extension on an element, any element below it in the DOM can use one of three attributes named <template-engine>-template (e.g. mustache-template) with a template ID, and the extension will resolve and render the template the standard way for that template engine:
+
+    mustache - looks a mustache <script> tag up by ID for the template content
+    handlebars - looks in the Handlebars.partials collection for a template with that name
+    nunjucks - resolves the template by name via `nunjucks.render()
+
+The AJAX response body will be parsed as JSON and passed into the template rendering.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/client-side-templates.js"></script>
+
+Usage
+<div hx-ext="client-side-templates">
+  <button hx-get="/some_json"
+          mustache-template="my-mustache-template">
+     Handle with mustache
+  </button>
+  <button hx-get="/some_json"
+          handlebars-template="my-handlebars-template">
+     Handle with handlebars
+  </button>
+  <button hx-get="/some_json"
+          nunjucks-template="my-nunjucks-template">
+     Handle with nunjucks
+  </button>
+</div>
+
+Full HTML Example
+
+To use the client side template, you will need to include htmx, the extension, and the rendering engine. Here is an example of this setup for Mustache using a <template> tag.
+
+If you wish to put a template into another file, you can use a directive such as <script src="my-template" id="template-id" type="text/mustache">
+
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>JS Bin</title>
+  <script src="https://unpkg.com/htmx.org"></script>
+  <script src="https://unpkg.com/htmx.org/dist/ext/client-side-templates.js"></script>
+  <script src="https://unpkg.com/mustache@latest"></script>
+</head>
+<body>
+  <div hx-ext="client-side-templates">
+    <button hx-get="https://jsonplaceholder.typicode.com/todos/1"
+            hx-swap="innerHTML"
+            hx-target="#content"
+            mustache-template="foo">
+      Click Me
+    </button>
+
+    <p id="content">Start</p>
+
+    <template id="foo">
+      <p> {% raw %}{{userID}}{% endraw %} and {% raw %}{{id}}{% endraw %} and {% raw %}{{title}}{% endraw %} and {% raw %}{{completed}}{% endraw %}</p>
+    </template>
+  </div>
+</body>
+</html>
+

--- a/lsp/src/htmx/hx-ext/client-side-templates.md
+++ b/lsp/src/htmx/hx-ext/client-side-templates.md
@@ -39,30 +39,30 @@ If you wish to put a template into another file, you can use a directive such as
 
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width">
-  <title>JS Bin</title>
-  <script src="https://unpkg.com/htmx.org"></script>
-  <script src="https://unpkg.com/htmx.org/dist/ext/client-side-templates.js"></script>
-  <script src="https://unpkg.com/mustache@latest"></script>
-</head>
-<body>
-  <div hx-ext="client-side-templates">
-    <button hx-get="https://jsonplaceholder.typicode.com/todos/1"
-            hx-swap="innerHTML"
-            hx-target="#content"
-            mustache-template="foo">
-      Click Me
-    </button>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>JS Bin</title>
+    <script src="https://unpkg.com/htmx.org"></script>
+    <script src="https://unpkg.com/htmx.org/dist/ext/client-side-templates.js"></script>
+    <script src="https://unpkg.com/mustache@latest"></script>
+  </head>
+  <body>
+    <div hx-ext="client-side-templates">
+      <button hx-get="https://jsonplaceholder.typicode.com/todos/1"
+              hx-swap="innerHTML"
+              hx-target="#content"
+              mustache-template="foo">
+        Click Me
+      </button>
 
-    <p id="content">Start</p>
+      <p id="content">Start</p>
 
-    <template id="foo">
-      <p> {% raw %}{{userID}}{% endraw %} and {% raw %}{{id}}{% endraw %} and {% raw %}{{title}}{% endraw %} and {% raw %}{{completed}}{% endraw %}</p>
-    </template>
-  </div>
-</body>
+      <template id="foo">
+        <p> {% raw %}{{userID}}{% endraw %} and {% raw %}{{id}}{% endraw %} and {% raw %}{{title}}{% endraw %} and {% raw %}{{completed}}{% endraw %}</p>
+      </template>
+    </div>
+  </body>
 </html>
 
 [HTMX Reference](https://htmx.org/extensions/client-side-templates/)

--- a/lsp/src/htmx/hx-ext/debug.md
+++ b/lsp/src/htmx/hx-ext/debug.md
@@ -6,3 +6,4 @@ Install
 Usage
 <button hx-ext="debug">Debug Me...</button>
 
+[HTMX Reference](https://htmx.org/extensions/debug/)

--- a/lsp/src/htmx/hx-ext/debug.md
+++ b/lsp/src/htmx/hx-ext/debug.md
@@ -1,0 +1,8 @@
+This extension includes log all htmx events for the element it is on, either through the console.debug function or through the console.log function with a DEBUG: prefix.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/debug.js"></script>
+
+Usage
+<button hx-ext="debug">Debug Me...</button>
+

--- a/lsp/src/htmx/hx-ext/disable-element.md
+++ b/lsp/src/htmx/hx-ext/disable-element.md
@@ -1,0 +1,13 @@
+This extension disables an element during an htmx request, when configured on the element triggering the request.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/disable-element.js"></script>
+
+Usage
+Nominal case: disabling the element triggering the request
+<button hx-get="/whatever" hx-ext="disable-element" hx-disable-element="self">Click me</button>
+
+Disabling another element
+<button hx-get="/whatever" hx-ext="disable-element" hx-disable-element="#to-disable">Click me</button>
+<button id="to-disable">Watch me being disabled</button>
+

--- a/lsp/src/htmx/hx-ext/disable-element.md
+++ b/lsp/src/htmx/hx-ext/disable-element.md
@@ -11,3 +11,4 @@ Disabling another element
 <button hx-get="/whatever" hx-ext="disable-element" hx-disable-element="#to-disable">Click me</button>
 <button id="to-disable">Watch me being disabled</button>
 
+[HTMX Reference](https://htmx.org/extensions/disable-element/)

--- a/lsp/src/htmx/hx-ext/event-header.md
+++ b/lsp/src/htmx/hx-ext/event-header.md
@@ -9,3 +9,5 @@ Usage
 </button>
 Sends something like this:
 Triggering-Event: '{ "isTrusted": false, "htmx-internal-data": { "handled": true }, "screenX": 0
+
+[HTMX Reference](https://htmx.org/extensions/event-header/)

--- a/lsp/src/htmx/hx-ext/event-header.md
+++ b/lsp/src/htmx/hx-ext/event-header.md
@@ -1,0 +1,11 @@
+This extension adds the Triggering-Event header to requests. The value of the header is a JSON serialized version of the event that triggered the request.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/event-header.js"></script>
+
+Usage
+<button hx-ext="event-header">
+   Click Me!
+</button>
+Sends something like this:
+Triggering-Event: '{ "isTrusted": false, "htmx-internal-data": { "handled": true }, "screenX": 0

--- a/lsp/src/htmx/hx-ext/head-support.md
+++ b/lsp/src/htmx/hx-ext/head-support.md
@@ -1,0 +1,90 @@
+The head-support extension adds support for head tags in responses to htmx requests.
+
+htmx began as a library focused on partial replacement of HTML within the body tag. As such, merging additional information such as the head tag was not a focus of the library. (This is in contrast with, for example, TurboLinks, which was focused on merging entire web pages retrieved via AJAX into the browser.)
+
+The hx-boost attribute moved htmx closer to this world of full HTML-document support & support for extracting the title tag out of head elements was eventually added, but full head tag support has never been a feature of the library.
+
+This extension addresses that shortcoming & will likely be integrated into htmx for the 2.0 release.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/head-support.js"></script>
+
+Usage
+<body hx-ext="head-support">
+   ...
+</body>
+
+With this installed, all responses that htmx receives that contain a head tag in them (even if they are not complete HTML documents with a root <html> element) will be processed.
+
+How the head tag is handled depends on the type of htmx request.
+
+If the htmx request is from a boosted element, then the following merge algorithm is used:
+
+    Elements that exist in the current head as exact textual matches will be left in place
+    Elements that do not exist in the current head will be added at the end of the head tag
+    Elements that exist in the current head, but not in the new head will be removed from the head
+
+If the htmx request is from a non-boosted element, then all content will be appended to the existing head element.
+
+If you wish to override this behavior in either case, you can place the hx-head attribute on the new <head> tag, with either of the following two values:
+
+    merge - follow the merging algorithm outlined above
+    append - append the elements to the existing head
+
+Controlling Merge Behavior
+
+Beyond this, you may also control merging behavior of individual elements with the following attributes:
+
+    If you place hx-head="re-eval" on a head element, it will be re-added (removed and appended) to the head tag on every request, even if it already exists. This can be useful to execute a script on every htmx request, for example.
+    If you place hx-preserve="true" on an element, it will never be removed from the head
+
+Example
+
+As an example, consider the following head tag in an existing document:
+
+<head>
+    <link rel="stylesheet" href="https://the.missing.style">
+    <link rel="stylesheet" href="/css/site1.css">
+    <script src="/js/script1.js"></script>
+    <script src="/js/script2.js"></script>
+</head>
+
+If htmx receives a request containing this new head tag:
+
+<head>
+    <link rel="stylesheet" href="https://the.missing.style">
+    <link rel="stylesheet" href="/css/site2.css">
+    <script src="/js/script2.js"></script>
+    <script src="/js/script3.js"></script>
+</head>
+
+Then the following operations will occur:
+
+    <link rel="stylesheet" href="https://the.missing.style"> will be left alone
+    <link rel="stylesheet" href="/css/site1.css"> will be removed from the head
+    <link rel="stylesheet" href="/css/site2.css"> will be added to the head
+    <script src="/js/script1.js"></script> will be removed from the head
+    <script src="/js/script2.js"></script> will be left alone
+    <script src="/js/script3.js"></script> will be added to the head
+
+The final head element will look like this:
+
+<head>
+    <link rel="stylesheet" href="https://the.missing.style">
+    <script src="/js/script2.js"></script>
+    <link rel="stylesheet" href="/css/site2.css">
+    <script src="/js/script3.js"></script>
+</head>
+
+Events
+
+This extension triggers the following events:
+
+    htmx:removingHeadElement - triggered when a head element is about to be removed, with the element being removed available in event.detail.headElement. If preventDefault() is invoked on the event, the element will not be removed.
+    htmx:addingHeadElement - triggered when a head element is about to be added, with the element being added available in event.detail.headElement. If preventDefault() is invoked on the event, the element will not be added.
+    htmx:afterHeadMerge - triggered after a head tag merge has occurred, with the following values available in the event detail:
+        added - added head elements
+        kept - kept head elements
+        removed - removed head elements
+    htmx:beforeHeadMerge - triggered before a head merge occurs
+

--- a/lsp/src/htmx/hx-ext/head-support.md
+++ b/lsp/src/htmx/hx-ext/head-support.md
@@ -88,3 +88,4 @@ This extension triggers the following events:
         removed - removed head elements
     htmx:beforeHeadMerge - triggered before a head merge occurs
 
+[HTMX Reference](https://htmx.org/extensions/head-support/)

--- a/lsp/src/htmx/hx-ext/include-vals.md
+++ b/lsp/src/htmx/hx-ext/include-vals.md
@@ -1,0 +1,11 @@
+The include-vals extension allows you to programmatically include values in a request with a include-vals attribute. The value of this attribute is one or more name/value pairs, which will be evaluated as the fields in a javascript object literal.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/include-vals.js"></script>
+
+Usage
+<div hx-ext="include-vals">
+    <div hx-get="/test" include-vals="included:true, computed: computeValue()">
+      Will Include Additional Values
+    </div>
+</div>

--- a/lsp/src/htmx/hx-ext/include-vals.md
+++ b/lsp/src/htmx/hx-ext/include-vals.md
@@ -9,3 +9,5 @@ Usage
       Will Include Additional Values
     </div>
 </div>
+
+[HTMX Reference](https://htmx.org/extensions/include-vals/)

--- a/lsp/src/htmx/hx-ext/json-enc.md
+++ b/lsp/src/htmx/hx-ext/json-enc.md
@@ -1,0 +1,7 @@
+This extension encodes parameters in JSON format instead of url format.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/json-enc.js"></script>
+
+Usage
+<div hx-post='/test' hx-ext='json-enc'>click me</div>

--- a/lsp/src/htmx/hx-ext/json-enc.md
+++ b/lsp/src/htmx/hx-ext/json-enc.md
@@ -5,3 +5,5 @@ Install
 
 Usage
 <div hx-post='/test' hx-ext='json-enc'>click me</div>
+
+[HTMX Reference](https://htmx.org/extensions/json-enc/)

--- a/lsp/src/htmx/hx-ext/loading-states.md
+++ b/lsp/src/htmx/hx-ext/loading-states.md
@@ -106,4 +106,4 @@ This attribute is optional and it allows defining a scope for the loading states
   <div data-loading>loading</div>
 </form>
 
-
+[HTMX Reference](https://htmx.org/extensions/loading-states/)

--- a/lsp/src/htmx/hx-ext/loading-states.md
+++ b/lsp/src/htmx/hx-ext/loading-states.md
@@ -1,0 +1,109 @@
+This extension allows you to easily manage loading states while a request is in flight, including disabling elements, and adding and removing CSS classes.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/loading-states.js"></script>
+
+Usage
+Add the hx-ext="loading-states" attribute to the body tag or to any parent element containing your htmx attributes.
+
+Add the following class to your stylesheet to make sure elements are hidden by default:
+
+[data-loading] {
+  display: none;
+}
+
+Supported attributes
+
+data-loading
+
+Shows the element. The default style is inline-block, but it’s possible to use any display style by specifying it in the attribute value.
+
+<div data-loading>loading</div>
+
+<div data-loading="block">loading</div>
+
+<div data-loading="flex">loading</div>
+
+data-loading-class
+
+Adds, then removes, CSS classes to the element:
+
+<div class="transition-all ease-in-out duration-600" data-loading-class="bg-gray-100 opacity-80">
+...
+</div>
+
+data-loading-class-remove
+
+Removes, then adds back, CSS classes from the element.
+
+<div class="p-8 bg-gray-100 transition-all ease-in-out duration-600" data-loading-class-remove="bg-gray-100">
+...
+</div>
+
+data-loading-disable
+
+Disables an element for the duration of the request.
+
+<button data-loading-disable>Submit</button>
+
+data-loading-aria-busy
+
+Add aria-busy="true" attribute to the element for the duration of the request
+
+<button data-loading-aria-busy>Submit</button>
+
+data-loading-delay
+
+Some actions may update quickly and showing a loading state in these cases may be more of a distraction. This attribute ensures that the loading state changes are applied only after 200ms if the request is not finished. The default delay can be modified through the attribute value and expressed in milliseconds:
+
+<button type="submit" data-loading-disable data-loading-delay="1000">Submit</button>
+
+You can place the data-loading-delay attribute directly on the element you want to disable, or in any parent element.
+
+data-loading-target
+
+Allows setting a different target to apply the loading states. The attribute value can be any valid CSS selector. The example below disables the submit button and shows the loading state when the form is submitted.
+
+<form hx-post="/save"
+  data-loading-target="#loading"
+  data-loading-class-remove="hidden">
+
+  <button type="submit" data-loading-disable>Submit</button>
+
+</form>
+
+<div id="loading" class="hidden">Loading ...</div>
+
+data-loading-path
+
+Allows filtering the processing of loading states only for specific requests based on the request path.
+
+<form hx-post="/save">
+  <button type="submit" data-loading-disable data-loading-path="/save">Submit</button>
+</form>
+
+You can place the data-loading-path attribute directly on the loading state element, or in any parent element.
+
+<form hx-post="/save" data-loading-path="/save">
+  <button type="submit" data-loading-disable>Submit</button>
+</form>
+
+data-loading-states
+
+This attribute is optional and it allows defining a scope for the loading states so only elements within that scope are processed.
+
+<div data-loading-states>
+  <div hx-get=""></div>
+  <div data-loading>loading</div>
+</div>
+
+<div data-loading-states>
+  <div hx-get=""></div>
+  <div data-loading>loading</div>
+</div>
+
+<form data-loading-states hx-post="">
+  <div data-loading>loading</div>
+</form>
+
+

--- a/lsp/src/htmx/hx-ext/method-override.md
+++ b/lsp/src/htmx/hx-ext/method-override.md
@@ -1,0 +1,12 @@
+This extension makes non-GET and POST requests use a POST with the X-HTTP-Method-Override header set to the actual HTTP method. This is necessary when dealing with some firewall or proxy situations.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/method-override.js"></script>
+
+Usage
+<body hx-ext="method-override">
+   <button hx-put="/update">
+     This request will be made as a POST w/ the X-HTTP-Method-Override Header Set
+</button>
+</body>
+

--- a/lsp/src/htmx/hx-ext/method-override.md
+++ b/lsp/src/htmx/hx-ext/method-override.md
@@ -5,9 +5,9 @@ Install
 
 Usage
 <body hx-ext="method-override">
-   <button hx-put="/update">
-     This request will be made as a POST w/ the X-HTTP-Method-Override Header Set
-</button>
+    <button hx-put="/update">
+        This request will be made as a POST w/ the X-HTTP-Method-Override Header Set
+    </button>
 </body>
 
 [HTMX Reference](https://htmx.org/extensions/method-override/)

--- a/lsp/src/htmx/hx-ext/method-override.md
+++ b/lsp/src/htmx/hx-ext/method-override.md
@@ -10,3 +10,4 @@ Usage
 </button>
 </body>
 
+[HTMX Reference](https://htmx.org/extensions/method-override/)

--- a/lsp/src/htmx/hx-ext/morph.md
+++ b/lsp/src/htmx/hx-ext/morph.md
@@ -1,0 +1,28 @@
+Idiomorph is a javascript library for morphing one DOM tree to another. It is inspired by other libraries that pioneered this functionality:
+
+    morphdom - the original DOM morphing library
+    nanomorph - an updated take on morphdom
+
+Both morphdom and nanomorph use the id property of a node to match up elements within a given set of sibling nodes. When an id match is found, the existing element is not removed from the DOM, but is instead morphed in place to the new content. This preserves the node in the DOM, and allows state (such as focus) to be retained.
+
+However, in both these algorithms, the structure of the children of sibling nodes is not considered when morphing two nodes: only the ids of the nodes are considered. This is due to performance: it is not feasible to recurse through all the children of siblings when matching things up.
+
+Install
+<script src="https://unpkg.com/idiomorph/dist/idiomorph-ext.min.js"></script>
+
+Usage
+<div hx-ext="morph">
+
+    <button hx-get="/example" hx-swap="morph:innerHTML">
+        Morph My Inner HTML
+    </button>
+
+    <button hx-get="/example" hx-swap="morph:outerHTML">
+        Morph My Outer HTML
+    </button>
+
+    <button hx-get="/example" hx-swap="morph">
+        Morph My Outer HTML
+    </button>
+
+</div>

--- a/lsp/src/htmx/hx-ext/morph.md
+++ b/lsp/src/htmx/hx-ext/morph.md
@@ -27,4 +27,4 @@ Usage
 
 </div>
 
-[HTMX Reference](https://github.com/bigskysoftware/idiomorph)
+[Idiomorph Reference](https://github.com/bigskysoftware/idiomorph)

--- a/lsp/src/htmx/hx-ext/morph.md
+++ b/lsp/src/htmx/hx-ext/morph.md
@@ -26,3 +26,5 @@ Usage
     </button>
 
 </div>
+
+[HTMX Reference](https://github.com/bigskysoftware/idiomorph)

--- a/lsp/src/htmx/hx-ext/morphdom-swap.md
+++ b/lsp/src/htmx/hx-ext/morphdom-swap.md
@@ -1,0 +1,14 @@
+This extension allows you to use the morphdom library as the swapping mechanism in htmx.
+The morphdom library does not support morph element to multiple elements. If the result of hx-select is more than one element, it will pick the first one.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/morphdom-swap.js"></script>
+
+Usage
+<header>
+  <script src="lib/morphdom-umd.js"></script> <!-- include the morphdom library -->
+</header>
+<body hx-ext="morphdom-swap">
+   <button hx-swap="morphdom">This button will be swapped with morphdom!</button>
+</body>
+

--- a/lsp/src/htmx/hx-ext/morphdom-swap.md
+++ b/lsp/src/htmx/hx-ext/morphdom-swap.md
@@ -12,3 +12,4 @@ Usage
    <button hx-swap="morphdom">This button will be swapped with morphdom!</button>
 </body>
 
+[HTMX Reference](https://htmx.org/extensions/morphdom-swap/)

--- a/lsp/src/htmx/hx-ext/multi-swap.md
+++ b/lsp/src/htmx/hx-ext/multi-swap.md
@@ -56,3 +56,4 @@ Notes and limitations
     If the delete swap method is used, the HTML response must also contain deleted element (it can be empty div with id attribute).
     Only elements with an id selector are supported, as the function internally uses OOB internal method. So it is not possible to use class or any other selectors.
 
+[HTMX Reference](https://htmx.org/extensions/multi-swap/)

--- a/lsp/src/htmx/hx-ext/multi-swap.md
+++ b/lsp/src/htmx/hx-ext/multi-swap.md
@@ -1,0 +1,58 @@
+This extension allows you to swap multiple elements marked with the id attribute from the HTML response. You can also choose for each element which swap method should be used.
+
+Multi-swap can help in cases where OOB (Out of Band Swaps) is not enough for you. OOB requires HTML tags marked with hx-swap-oob attributes to be at the TOP level of HTML, which significantly limited its use. With OOB is not possible to swap multiple elements arbitrarily placed and nested in the DOM tree.
+
+It is a very powerful tool in conjunction with hx-boost and preload extension.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/multi-swap.js"></script>
+
+Usage
+
+Set hx-ext="multi-swap" attribute on <body>, on some parent element, or on each action element that should trigger an action (typically anchors or buttons).
+On your action elements set hx-swap="multi:ID-SELECTORS", e.g. hx-swap="multi:#id1,#id2:outerHTML,#id3:afterend".
+If you’re not using e.g. hx-get to enable HTMX behavior, set hx-boost="true" on your action elements, or on some parent element, so that all elements inherit the hx-boost setting.
+
+Selectors must be separated by a comma (without surrounding spaces) and a colon with the desired swap method can optionally be placed after the selector. Default swap method is innerHTML.
+
+<body hx-boost="true" hx-ext="multi-swap">
+   <!-- simple example how to swap #id1 and #id2 from /example by innerHTML (default swap method) -->
+   <button hx-get="/example" hx-swap="multi:#id1,#id2">Click to swap #id1 and #id2 content</button>
+
+   <!-- advanced example how to swap multiple elements from /example by different swap methods -->
+   <a href="/example" hx-swap="multi:#id1,#id2:outerHTML,#id3:beforeend,#id4:delete">Click to swap #id1 and #id2, extend #id3 content and delete #id4 element</a>
+
+   <div id="id1">Old 1 content</div>
+   <div id="id2">Old 2 content</div>
+   <div id="id3">Old 3 content</div>
+   <div id="id4">Old 4 content</div>
+</body>
+
+Real world example with preloading
+
+The use case below shows how to ensure that only the #submenu and #content elements are redrawn when the main menu items are clicked. Thanks to the combination with the preload extension, the page, including its images, is preloaded on mouseover event.
+
+<head>
+  <script src="/path/to/htmx.js"></script>
+  <script src="/path/to/ext/multi-swap.js"></script>
+  <script src="/path/to/ext/preload.js"></script>
+</head>
+<body hx-ext="multi-swap,preload">
+  <header>...</header>
+  <menu hx-boost="true">
+    <ul>
+      <li><a href="/page-1" hx-swap="multi:#submenu,#content" preload="mouseover" preload-images="true">Page 1</a></li>
+      <li><a href="/page-2" hx-swap="multi:#submenu,#content" preload="mouseover" preload-images="true">Page 2</a></li>
+    </ul>
+    <div id="submenu">... submenu contains items by selected top-level menu ...</div>
+  <menu>
+  <main id="content">...</div>
+  <footer>...</footer>
+</body>
+
+Notes and limitations
+
+    Attribute hx-swap value must not contain spaces, otherwise only the part of the value up to the first space will be accepted.
+    If the delete swap method is used, the HTML response must also contain deleted element (it can be empty div with id attribute).
+    Only elements with an id selector are supported, as the function internally uses OOB internal method. So it is not possible to use class or any other selectors.
+

--- a/lsp/src/htmx/hx-ext/path-deps.md
+++ b/lsp/src/htmx/hx-ext/path-deps.md
@@ -37,3 +37,4 @@ Example
   // Trigger a refresh on all elements with the path-deps attribute '/path/to/refresh', including elements with a parent path, e.g. '/path'
   PathDeps.refresh('/path/to/refresh');
 
+[HTMX Reference](https://htmx.org/extensions/path-deps/)

--- a/lsp/src/htmx/hx-ext/path-deps.md
+++ b/lsp/src/htmx/hx-ext/path-deps.md
@@ -1,0 +1,39 @@
+This extension supports expressing inter-element dependencies based on paths, inspired by the intercooler.js dependencies mechanism. When this extension is installed an element can express a dependency on another path by using the path-deps property and then setting hx-trigger to path-deps:
+
+  <div hx-get="/example"
+       hx-trigger="path-deps"
+       path-deps="/foo/bar">...</div>
+
+This div will fire a GET request to /example when any other element issues a mutating request (that is, a non-GET request like a POST) to /foo/bar or any sub-paths of that path.
+
+You can use a * to match any path component:
+
+  <div hx-get="/example"
+       hx-trigger="path-deps"
+       path-deps="/contacts/*">...</div>
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/path-deps.js"></script>
+
+Usage
+<div hx-ext='path-deps'>
+  <ul hx-get="/list" hx-trigger="path-deps" path-deps="/list">
+  </ul>
+  <button hx-post="/list">
+     Post To List
+  </button>
+</div>
+
+Javascript API
+Method - PathDeps.refresh()
+
+This method manually triggers a refresh for the given path.
+Parameters
+
+    path - the path to refresh
+
+Example
+
+  // Trigger a refresh on all elements with the path-deps attribute '/path/to/refresh', including elements with a parent path, e.g. '/path'
+  PathDeps.refresh('/path/to/refresh');
+

--- a/lsp/src/htmx/hx-ext/path-deps.md
+++ b/lsp/src/htmx/hx-ext/path-deps.md
@@ -17,11 +17,11 @@ Install
 
 Usage
 <div hx-ext='path-deps'>
-  <ul hx-get="/list" hx-trigger="path-deps" path-deps="/list">
-  </ul>
-  <button hx-post="/list">
-     Post To List
-  </button>
+    <ul hx-get="/list" hx-trigger="path-deps" path-deps="/list">
+    </ul>
+    <button hx-post="/list">
+        Post To List
+    </button>
 </div>
 
 Javascript API

--- a/lsp/src/htmx/hx-ext/preload.md
+++ b/lsp/src/htmx/hx-ext/preload.md
@@ -1,0 +1,83 @@
+The preload extension allows you to load HTML fragments into your browser’s cache before they are requested by the user, so that additional pages appear to users to load nearly instantaneously. As a developer, you can customize its behavior to fit your applications needs and use cases.
+
+IMPORTANT: Preloading content judiciously can improve your web application’s perceived performance, but preloading too many resources can negatively impact your visitors’ bandwidth and your server performance by initiating too many unused requests. Use this extension carefully!
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/preload.js"></script>
+
+Usage
+Register the extension with htmx using the hx-ext attribute. Then, add a preload attribute to any hyperlinks and hx-get elements you want to preload. By default, resources will be loaded as soon as the mousedown event begins, giving your application a roughly 100-200ms head start on serving responses. See configuration below for other options.
+
+<body hx-ext="preload">
+    <h1>What Works</h2>
+    <a href="/server/1" preload>WILL BE requested using a standard XMLHttpRequest() and default options (below)</a>
+    <button hx-get="/server/2" preload>WILL BE requested with additional htmx headers.</button>
+
+    <h1>What WILL NOT WORK</h1>
+    <a href="/server/3">WILL NOT be preloaded because it does not have an explicit "preload" attribute</a>
+    <a hx-post="/server/4" preload>WILL NOT be preloaded because it is an HX-POST transaction.</a>
+</body>
+
+Inheriting Preload Settings
+
+You can add the preload attribute to the top-level element that contains several <a href=""> or hx-get="" elements, and all of them will be preloaded. Be careful with this setting, because you can end up wasting bandwidth if you preload many more resources than you need.
+
+<body hx-ext="preload">
+    <ul preload>
+        <li><a href="/server/1">This will be preloaded because of the attribute in the node above.</a>
+        <li><a href="/server/2">This will also be preloaded for the same reason.</a>
+        <li><a href="/server/3">This will be preloaded, too.  Lorem ipsum.</a>
+    </ul>
+</body>
+
+Preloading of Linked Images
+
+After an HTML page (or page fragment) is preloaded, this extension can also preload linked image resources. It will not load or run linked Javascript or Cascading Stylesheet content, whether linked or embedded in the preloaded HTML. To preload images as well, use the following syntax.
+
+<div hx-ext="preload">
+    <a href="/my-next-page" preload="mouseover" preload-images="true">Next Page</a>
+</div>
+
+Configuration
+
+Defaults for this extension are chosen to balance users’ perceived performance with potential load on your servers from unused requests. As a developer, you can modify two settings to customize this behavior to your specific use cases.
+
+preload=“mousedown” (DEFAULT)
+
+The default behavior for this extension is to begin loading a resource when the user presses the mouse down. This is a conservative setting that guarantees the user actually intends to use the linked resource. Because user click events typically take 100-200ms to complete, this setting gives your server a significant headstart compared with a regular click.
+
+<a href="/server/1" preload="mousedown">This will be preloaded when the user begins to cli
+
+preload=“mouseover”
+
+To preload links more aggressively, you can trigger the preload to happen when the user’s mouse hovers over the link instead. To prevent many resources from being loaded when the user scrolls or moves the mouse across a large list of objects, a 100ms delay is built in to this action. If the user’s mouse leaves the element before this timeout expires, then the resource is not preloaded.
+
+Typical users hover over links for several hundred milliseconds before they click, which gives your server even more time to respond to the request than the mousedown option above. Test your own hover timing here.. However, be careful when using this option because it can increase server load by requesting resources unnecessarily.
+
+<a href="/server/1" preload="mouseover">This will be preloaded when the user's mouse remains
+
+preload=“custom-event-name”
+
+Preload can also listen to any custom event within the system, triggering resources to be preloaded (if they have not already been cached by the browser). The extension itself generates an event called preload:init that can be used to trigger preloads as soon as an object has been processed by htmx.
+
+<body hx-ext="preload">
+    <button hx-get="/server" preload="preload:init" hx-target="idLoadMore">Load More</a>
+    <div id="idLoadMore">
+        Content for this DIV will be preloaded as soon as the page is ready.
+        Clicking the button above will swap it into the DOM.
+    </div>
+</body>
+
+About Touch Events
+
+To accommodate touchscreen devices, an additional ontouchstart event handler is added whenever you specify a mouseover or mousedown trigger. This extra trigger fires immediately (no waiting period) whenever the user touches the screen, saving you 300ms of waiting time on Android, and 450ms on iOS.
+
+Limitations
+
+* Links must be marked with a preload attribute, or have an ancestor node that has the preload attribute.
+* Only GET transactions (including <a href=""> and hx-get="") can be preloaded. Following REST principles, GET transactions are assumed to not make any significant changes to a resource. Transactions that can potentially make a change (such as POST, PUT, and DELETE) will not be preloaded under any circumstances.
+* When listening to mouseover events, preload waits for 100ms before downloading the linked resource. If the mouse leaves the resource before this timeout expires, the resource is not preloaded.
+
+Credits
+
+The behavior for this plugin was inspired by the work done by Alexandre Dieulot on InstantClick, which is released under the MIT license.

--- a/lsp/src/htmx/hx-ext/preload.md
+++ b/lsp/src/htmx/hx-ext/preload.md
@@ -81,3 +81,5 @@ Limitations
 Credits
 
 The behavior for this plugin was inspired by the work done by Alexandre Dieulot on InstantClick, which is released under the MIT license.
+
+[HTMX Reference](https://htmx.org/extensions/preload/)

--- a/lsp/src/htmx/hx-ext/remove-me.md
+++ b/lsp/src/htmx/hx-ext/remove-me.md
@@ -1,0 +1,10 @@
+The remove-me extension allows you to remove an element after a specified interval.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/remove-me.js"></script>
+
+Usage
+<div hx-ext="remove-me">
+    <!-- Removes this div after 1 second -->
+    <div remove-me="1s">To Be Removed...</div>
+</div>

--- a/lsp/src/htmx/hx-ext/remove-me.md
+++ b/lsp/src/htmx/hx-ext/remove-me.md
@@ -8,3 +8,5 @@ Usage
     <!-- Removes this div after 1 second -->
     <div remove-me="1s">To Be Removed...</div>
 </div>
+
+[HTMX Reference](https://htmx.org/extensions/remove-me/)

--- a/lsp/src/htmx/hx-ext/response-targets.md
+++ b/lsp/src/htmx/hx-ext/response-targets.md
@@ -61,3 +61,4 @@ Configure (optional)
 * isError flag on the detail member of an event associated with swapping the content with hx-target-[CODE] will be set to false when error response code is received. This is different from the default behavior. You may change this by setting a configuration flag htmx.config.responseTargetUnsetsError to false (default is true).
 * isError flag on the detail member of an event associated with swapping the content with hx-target-[CODE] will be set to false when non-erroneous response code is received. This is no different from the default behavior. You may change this by setting a configuration flag htmx.config.responseTargetSetsError to true (default is false). This setting will not affect the response code 200 since it is not handled by this extension.
 
+[HTMX Reference](https://htmx.org/extensions/response-targets/)

--- a/lsp/src/htmx/hx-ext/response-targets.md
+++ b/lsp/src/htmx/hx-ext/response-targets.md
@@ -1,0 +1,63 @@
+This extension allows you to specify different target elements to be swapped when different HTTP response codes are received.
+
+It uses attribute names in a form of hx-target-[CODE] where [CODE] is a numeric HTTP response code with the optional wildcard character at its end.
+
+The value of each attribute can be:
+
+* A CSS query selector of the element to target.
+* this which indicates that the element that the hx-target attribute is on is the target.
+* closest <CSS selector> which will find the closest parent ancestor that matches the given CSS selector (e.g. closest tr will target the closest table row to the element).
+* find <CSS selector> which will find the first child descendant element that matches the given CSS selector.
+* next <CSS selector> which will scan the DOM forward for the first element that matches the given CSS selector. (e.g. next .error will target the closest following sibling element with error class)
+* previous <CSS selector> which will scan the DOM backwards for the first element that matches the given CSS selector. (e.g previous .error will target the closest previous sibling with error class)
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/response-targets.js"></script>
+
+Usage
+
+Here is an example that targets a div for normal (200) response but another div for 404 (not found) response, and yet another for all 5xx response codes:
+
+<div hx-ext="response-targets">
+    <div id="response-div"></div>
+    <button hx-post="/register"
+            hx-target="#response-div"
+            hx-target-5*="#serious-errors"
+            hx-target-404="#not-found">
+        Register!
+    </button>
+    <div id="serious-errors"></div>
+    <div id="not-found"></div>
+</div>
+
+* The response from the /register URL will replace contents of the div with the id response-div when response code is 200 (OK).
+* The response from the /register URL will replace contents of the div with the id serious-errors when response code begins with a digit 5 (server errors).
+* The response from the /register URL will will replace contents of the div with the id not-found when response code is 404 (Not Found).
+
+Wildcard resolution
+
+When status response code does not match existing hx-target-[CODE] attribute name then its numeric part expressed as a string is trimmed with last character being replaced with the asterisk (*). This lookup process continues until the attribute is found or there are no more digits.
+
+For example, if a browser receives 404 error code, the following attribute names will be looked up (in the given order):
+
+* hx-target-404
+* hx-target-40*
+* hx-target-4*
+* hx-target-*.
+
+If you are using tools that do not support asterisks in HTML attributes, you may instead use the x character, e.g., hx-target-4xx.
+
+Notes
+
+* hx-target-… is inherited and can be placed on a parent element.
+* hx-target-… cannot be used to handle HTTP response code 200.
+* hx-target-… will honor HX-Retarget by default and will prefer it over any calculated target but it can be changed by disabling the htmx.config.responseTargetPrefersRetargetHeader configuration option.
+* To avoid surprises the hx-ext attribute used to enable this extension should be placed on a parent element containing elements with hx-target-… and hx-target attributes.
+
+Configure (optional)
+
+* When HX-Retarget response header is received it disables any lookup that would be performed by this extension but any responses with error status codes will be swapped (normally they would not be, even with target set via header) and internal error flag (isError) will be modified. You may change this and choose to ignore HX-Retarget header when hx-target-… is in place by setting a configuration flag htmx.config.responseTargetPrefersRetargetHeader to false (default is true). Note that this extension only performs a simple check whether the header is set and target exists. It is not extracting target’s value from the header but trusts it was set by HTMX core logic.
+* Normally, any target which is already established by HTMX built-in functions or extensions called before will be overwritten if a matching hx-target-… tag is found. You may change it by using a configuration flag htmx.config.responseTargetPrefersExisting to true (default is false). This is kinky and risky option. It has a real-life applications similar to a skilled, full-stack tardigrade eating parentheses when no one is watching.
+* isError flag on the detail member of an event associated with swapping the content with hx-target-[CODE] will be set to false when error response code is received. This is different from the default behavior. You may change this by setting a configuration flag htmx.config.responseTargetUnsetsError to false (default is true).
+* isError flag on the detail member of an event associated with swapping the content with hx-target-[CODE] will be set to false when non-erroneous response code is received. This is no different from the default behavior. You may change this by setting a configuration flag htmx.config.responseTargetSetsError to true (default is false). This setting will not affect the response code 200 since it is not handled by this extension.
+

--- a/lsp/src/htmx/hx-ext/restored.md
+++ b/lsp/src/htmx/hx-ext/restored.md
@@ -1,0 +1,12 @@
+This extension triggers an event restored whenever a back button even is detected while using hx-boost.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/restored.js"></script>
+
+Usage
+A page utilizing hx-boost that will reload the h1 each time the back button is pressed:
+
+<body hx-boost="true">
+    <h1 hx-ext="restored" hx-trigger="restored" hx-get="/header">Come back!</h1>
+    <a href="/other_page">I'll be back</a>
+</body>

--- a/lsp/src/htmx/hx-ext/restored.md
+++ b/lsp/src/htmx/hx-ext/restored.md
@@ -10,3 +10,5 @@ A page utilizing hx-boost that will reload the h1 each time the back button is p
     <h1 hx-ext="restored" hx-trigger="restored" hx-get="/header">Come back!</h1>
     <a href="/other_page">I'll be back</a>
 </body>
+
+[HTMX Reference](https://htmx.org/extensions/restored/)

--- a/lsp/src/htmx/hx-ext/sse.md
+++ b/lsp/src/htmx/hx-ext/sse.md
@@ -1,0 +1,85 @@
+The Server Sent Events connects to an EventSource directly from HTML. It manages the connections to your web server, listens for server events, and then swaps their contents into your htmx webpage in real-time.
+
+SSE is a lightweight alternative to WebSockets that works over existing HTTP connections, so it is easy to use through proxy servers and firewalls. Remember, SSE is a uni-directional service, so you cannot send any messages to an SSE server once the connection has been established. If you need bi-directional communication, then you should consider using WebSockets instead.
+
+This extension replaces the experimental hx-sse attribute built into previous versions of htmx. For help migrating from older versions, see the migration guide at the bottom of this page.
+
+Use the following attributes to configure how SSE connections behave:
+
+* sse-connect="<url>" - The URL of the SSE server.
+* sse-swap="<message-name>" - The name of the message to swap into the DOM.
+* hx-trigger="sse:<message-name>" - SSE messages can also trigger HTTP callbacks using the hx-trigger attribute.
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/sse.js"></script>
+
+Usage
+<div hx-ext="sse" sse-connect="/chatroom" sse-swap="message">
+  Contents of this box will be updated in real time
+  with every SSE message received from the chatroom.
+</div>
+
+Connecting to an SSE Server
+
+To connect to an SSE server, use the hx-ext="sse" attribute to install the extension on that HTML element, then add sse-connect="<url>" to the element to make the connection.
+
+When designing your server application, remember that SSE works just like any HTTP request. Although you cannot send any messages to the server after you have established a connection, you can send parameters to the server along with your request. So, instead of making an SSE connection to your server at https://my-server/chat-updates you can also connect to https://my-server/chat-updates?friends=true&format=detailed. This allows your server to customize its responses to what your client needs.
+
+Receiving Named Events
+
+SSE messages consist of an event name and a data packet. No other metadata is allowed in the message. Here is an example:
+
+event: EventName
+data: <div>Content to swap into your HTML page.</div>
+
+We’ll use the sse-swap attribute to listen for this event and swap its contents into our webpage.
+
+<div hx-ext="sse" sse-connect="/event-source" sse-swap="EventName"></div>
+
+Notice that the name EventName from the server’s message must match the value in the sse-swap attribute. Your server can use as many different event names as necessary, but be careful: browsers can only listen for events that have been explicitly named. So, if your server sends an event named ChatroomUpdate but your browser is only listening for events named ChatUpdate then the extra event will be discarded.
+
+Receiving Unnamed Events
+
+SSE messages can also be sent without any event name. In this case, the browser uses the default name message in its place. The same rules specified above still apply. If your server sends an unnamed message, then you must listen for it by including sse-swap="message". There is no option for using a catch-all name. Here’s how this looks:
+
+data: <div>Content to swap into your HTML page.</div>
+
+<div hx-ext="sse" sse-connect="/event-source" sse-swap="message"></div>
+
+Receiving Multiple Events
+
+You can also listen to multiple events (named or unnamed) from a single EventSource. Listeners must be either 1) the same element that contains the hx-ext and sse-connect attributes, or 2) child elements of the element containing the hx-ext and sse-connect attributes.
+
+
+Multiple events in the same element
+<div hx-ext="sse" sse-connect="/server-url" sse-swap="event1,event2"></div>
+
+Multiple events in different elements (from the same source).
+<div hx-ext="sse" sse-connect="/server-url">
+    <div sse-swap="event1"></div>
+    <div sse-swap="event2"></div>
+</div>
+
+Trigger Server Callbacks
+
+When a connection for server sent events has been established, child elements can listen for these events by using the special hx-trigger syntax sse:<event_name>. This, when combined with an hx-get or similar will trigger the element to make a request.
+
+Here is an example:
+
+  <div hx-ext="sse" sse-connect="/event_stream">
+    <div hx-get="/chatroom" hx-trigger="sse:chatter">
+      ...
+    </div>
+  </div>
+
+This example establishes an SSE connection to the event_stream end point which then triggers a GET to the /chatroom url whenever the chatter event is seen.
+
+Automatic Reconnection
+
+If the SSE Event Stream is closed unexpectedly, browsers are supposed to attempt to reconnect automatically. However, in rare situations this does not work and your browser can be left hanging. This extension adds its own reconnection logic (using an exponential-backoff algorithm) on top of the browser’s automatic reconnection, so that your SSE streams will always be as reliable as possible.
+
+Testing SSE Connections with the Demo Server
+
+Htmx includes a demo SSE server written in Go that will help you to see SSE in action, and begin bootstrapping your own SSE code. It is located in the /test/servers/sse folder of the htmx distribution. Look at /test/servers/ws/README.md for instructions on running and using the test server.
+
+

--- a/lsp/src/htmx/hx-ext/sse.md
+++ b/lsp/src/htmx/hx-ext/sse.md
@@ -66,11 +66,11 @@ When a connection for server sent events has been established, child elements ca
 
 Here is an example:
 
-  <div hx-ext="sse" sse-connect="/event_stream">
+<div hx-ext="sse" sse-connect="/event_stream">
     <div hx-get="/chatroom" hx-trigger="sse:chatter">
-      ...
+        ...
     </div>
-  </div>
+</div>
 
 This example establishes an SSE connection to the event_stream end point which then triggers a GET to the /chatroom url whenever the chatter event is seen.
 

--- a/lsp/src/htmx/hx-ext/sse.md
+++ b/lsp/src/htmx/hx-ext/sse.md
@@ -82,4 +82,4 @@ Testing SSE Connections with the Demo Server
 
 Htmx includes a demo SSE server written in Go that will help you to see SSE in action, and begin bootstrapping your own SSE code. It is located in the /test/servers/sse folder of the htmx distribution. Look at /test/servers/ws/README.md for instructions on running and using the test server.
 
-
+[HTMX Reference](https://htmx.org/extensions/server-sent-events/)

--- a/lsp/src/htmx/hx-ext/ws.md
+++ b/lsp/src/htmx/hx-ext/ws.md
@@ -1,0 +1,68 @@
+The WebSockets extension enables easy, bi-directional communication with Web Sockets servers directly from HTML. This replaces the experimental hx-ws attribute built into previous versions of htmx. For help migrating from older versions, see the Migrating guide at the bottom of this page.
+
+Use the following attributes to configure how WebSockets behave:
+
+* ws-connect="<url>" or ws-connect="<prefix>:<url>" - A URL to establish an WebSocket connection against.
+* Prefixes ws or wss can optionally be specified. If not specified, HTMX defaults to add the location’s scheme-type, host and port to have browsers send cookies via websockets.
+* ws-send - Sends a message to the nearest websocket based on the trigger value for the element (either the natural event or the event specified by [hx-trigger])
+
+Install
+<script src="https://unpkg.com/htmx.org/dist/ext/ws.js"></script>
+
+Usage
+<div hx-ext="ws" ws-connect="/chatroom">
+    <div id="notifications"></div>
+    <div id="chat_room">
+        ...
+    </div>
+    <form id="form" ws-send>
+        <input name="chat_message">
+    </form>
+</div>
+
+Configuration
+
+WebSockets extension support two configuration options:
+
+* createWebSocket - a factory function that can be used to create a custom WebSocket instances. Must be a function, returning WebSocket object
+* wsBinaryType - a string value, that defines socket’s binaryType property. Default value is blob
+
+Receiving Messages from a WebSocket
+
+The example above establishes a WebSocket to the /chatroom end point. Content that is sent down from the websocket will be parsed as HTML and swapped in by the id property, using the same logic as Out of Band Swaps.
+
+As such, if you want to change the swapping method (e.g., append content at the end of an element or delegate swapping to an extension), you need to specify that in the message body, sent by the server.
+
+<!-- will be interpreted as hx-swap-oob="true" by default -->
+<form id="form">
+    ...
+</form>
+<!-- will be appended to #notifications div -->
+<div id="notifications" hx-swap-oob="beforeend">
+    New message received
+</div>
+<!-- will be swapped using an extension -->
+<div id="chat_room" hx-swap-oob="morphdom">
+    ....
+</div>
+
+Sending Messages to a WebSocket
+
+In the example above, the form uses the ws-send attribute to indicate that when it is submitted, the form values should be serialized as JSON and send to the nearest enclosing WebSocket, in this case the /chatroom endpoint.
+
+The serialized values will include a field, HEADERS, that includes the headers normally submitted with an htmx request.
+
+Automatic Reconnection
+
+If the WebSocket is closed unexpectedly, due to Abnormal Closure, Service Restart or Try Again Later, this extension will attempt to reconnect until the connection is reestablished.
+
+By default, the extension uses a full-jitter exponential-backoff algorithm that chooses a randomized retry delay that grows exponentially over time. You can use a different algorithm by writing it into htmx.config.wsReconnectDelay. This function takes a single parameter, the number of retries, and returns the time (in milliseconds) to wait before trying again.
+
+// example reconnect delay that you shouldn't use because
+// it's not as good as the algorithm that's already in place
+htmx.config.wsReconnectDelay = function (retryCount) {
+    return retryCount * 1000 // return value in milliseconds
+}
+
+The extension also implements a simple queuing mechanism that keeps messages in memory when the socket is not in OPEN state and sends them once the connection is restored.
+

--- a/lsp/src/htmx/hx-ext/ws.md
+++ b/lsp/src/htmx/hx-ext/ws.md
@@ -66,3 +66,4 @@ htmx.config.wsReconnectDelay = function (retryCount) {
 
 The extension also implements a simple queuing mechanism that keeps messages in memory when the socket is not in OPEN state and sends them once the connection is restored.
 
+[HTMX Reference](https://htmx.org/extensions/web-sockets/)

--- a/lsp/src/htmx/hx-history/false.md
+++ b/lsp/src/htmx/hx-history/false.md
@@ -1,0 +1,3 @@
+prevent sensitive data being saved to the localStorage cache when htmx takes a snapshot of the page state.
+
+[HTMX Reference](https://htmx.org/attributes/hx-history/)

--- a/lsp/src/htmx/hx-params/none.md
+++ b/lsp/src/htmx/hx-params/none.md
@@ -1,0 +1,3 @@
+Include no parameters
+
+[HTMX Reference](https://htmx.org/attributes/hx-params/)

--- a/lsp/src/htmx/hx-params/not.md
+++ b/lsp/src/htmx/hx-params/not.md
@@ -1,0 +1,3 @@
+Include all except the comma separated list of parameter names
+
+[HTMX Reference](https://htmx.org/attributes/hx-params/)

--- a/lsp/src/htmx/hx-params/star.md
+++ b/lsp/src/htmx/hx-params/star.md
@@ -1,0 +1,3 @@
+Include all parameters (default)
+
+[HTMX Reference](https://htmx.org/attributes/hx-params/)

--- a/lsp/src/htmx/hx-push-url/false.md
+++ b/lsp/src/htmx/hx-push-url/false.md
@@ -1,0 +1,3 @@
+disable pushing the fetched URL if it would otherwise be pushed due to inheritance or hx-boost
+
+[HTMX Reference](https://htmx.org/attributes/hx-push-url/)

--- a/lsp/src/htmx/hx-push-url/true.md
+++ b/lsp/src/htmx/hx-push-url/true.md
@@ -1,0 +1,3 @@
+push the fetched URL into history.
+
+[HTMX Reference](https://htmx.org/attributes/hx-push-url/)

--- a/lsp/src/htmx/hx-replace-url/false.md
+++ b/lsp/src/htmx/hx-replace-url/false.md
@@ -1,0 +1,3 @@
+disable replacing the fetched URL if it would otherwise be replaced due to inheritance.
+
+[HTMX Reference](https://htmx.org/attributes/hx-replace-url/)

--- a/lsp/src/htmx/hx-replace-url/true.md
+++ b/lsp/src/htmx/hx-replace-url/true.md
@@ -1,0 +1,3 @@
+replace the fetched URL in the browser navigation bar.
+
+[HTMX Reference](https://htmx.org/attributes/hx-replace-url/)

--- a/lsp/src/htmx/hx-swap-oob/true.md
+++ b/lsp/src/htmx/hx-swap-oob/true.md
@@ -1,0 +1,3 @@
+equivalent to outerHTML, the element will be swapped inline
+
+[HTMX Reference](https://htmx.org/attributes/hx-history/)

--- a/lsp/src/htmx/hx-swap/afterbegin.md
+++ b/lsp/src/htmx/hx-swap/afterbegin.md
@@ -1,1 +1,4 @@
 prepends the content before the first child inside the target
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-swap/)

--- a/lsp/src/htmx/hx-swap/afterend.md
+++ b/lsp/src/htmx/hx-swap/afterend.md
@@ -1,1 +1,5 @@
 appends the content after the target in the targets parent element
+
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-swap/)

--- a/lsp/src/htmx/hx-swap/beforebegin.md
+++ b/lsp/src/htmx/hx-swap/beforebegin.md
@@ -1,1 +1,4 @@
 prepends the content before the target in the targets parent element
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-swap/)

--- a/lsp/src/htmx/hx-swap/beforeend.md
+++ b/lsp/src/htmx/hx-swap/beforeend.md
@@ -1,1 +1,4 @@
 appends the content after the last child inside the target
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-swap/)

--- a/lsp/src/htmx/hx-swap/delete.md
+++ b/lsp/src/htmx/hx-swap/delete.md
@@ -1,1 +1,4 @@
 deletes the target element regardless of the response
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-swap/)

--- a/lsp/src/htmx/hx-swap/innerHTML.md
+++ b/lsp/src/htmx/hx-swap/innerHTML.md
@@ -1,1 +1,4 @@
 the default, puts the content inside the target element
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-swap/)

--- a/lsp/src/htmx/hx-swap/none.md
+++ b/lsp/src/htmx/hx-swap/none.md
@@ -1,1 +1,4 @@
 does not append content from response (Out of Band Swaps and Response Headers will still be processed)
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-swap/)

--- a/lsp/src/htmx/hx-swap/outerHTML.md
+++ b/lsp/src/htmx/hx-swap/outerHTML.md
@@ -1,1 +1,4 @@
 replaces the entire target element with the returned content
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-swap/)

--- a/lsp/src/htmx/hx-sync/abort.md
+++ b/lsp/src/htmx/hx-sync/abort.md
@@ -1,0 +1,3 @@
+drop (ignore) this request if an existing request is in flight, and, if that is not the case, abort this request if another request occurs while it is still in flight
+
+[HTMX Reference](https://htmx.org/attributes/hx-sync/)

--- a/lsp/src/htmx/hx-sync/drop.md
+++ b/lsp/src/htmx/hx-sync/drop.md
@@ -1,0 +1,3 @@
+drop (ignore) this request if an existing request is in flight (the default)
+
+[HTMX Reference](https://htmx.org/attributes/hx-sync/)

--- a/lsp/src/htmx/hx-sync/queue.md
+++ b/lsp/src/htmx/hx-sync/queue.md
@@ -1,0 +1,9 @@
+place this request in the request queue associated with the given element
+
+The queue modifier can take an additional argument indicating exactly how to queue:
+
+    queue first - queue the first request to show up while a request is in flight
+    queue last - queue the last request to show up while a request is in flight
+    queue all - queue all requests that show up while a request is in flight
+
+[HTMX Reference](https://htmx.org/attributes/hx-sync/)

--- a/lsp/src/htmx/hx-sync/replace.md
+++ b/lsp/src/htmx/hx-sync/replace.md
@@ -1,0 +1,3 @@
+abort the current request, if any, and replace it with this request
+
+[HTMX Reference](https://htmx.org/attributes/hx-sync/)

--- a/lsp/src/htmx/hx-target/closest.md
+++ b/lsp/src/htmx/hx-target/closest.md
@@ -1,1 +1,4 @@
 closest <CSS selector> which will find the closest ancestor element or itself, that matches the given CSS selector (e.g. closest tr will target the closest table row to the element).
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-target/)

--- a/lsp/src/htmx/hx-target/find.md
+++ b/lsp/src/htmx/hx-target/find.md
@@ -1,2 +1,4 @@
 find <CSS selector> which will find the first child descendant element that matches the given CSS selector.
 
+
+[HTMX Reference](https://htmx.org/attributes/hx-target/)

--- a/lsp/src/htmx/hx-target/next.md
+++ b/lsp/src/htmx/hx-target/next.md
@@ -1,1 +1,4 @@
 next <CSS selector> which will scan the DOM forward for the first element that matches the given CSS selector. (e.g. next .error will target the closest following sibling element with error class)
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-target/)

--- a/lsp/src/htmx/hx-target/prev.md
+++ b/lsp/src/htmx/hx-target/prev.md
@@ -1,1 +1,4 @@
 previous <CSS selector> which will scan the DOM backwards for the first element that matches the given CSS selector. (e.g previous .error will target the closest previous sibling with error class)
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-target/)

--- a/lsp/src/htmx/hx-target/this.md
+++ b/lsp/src/htmx/hx-target/this.md
@@ -1,1 +1,4 @@
 this which indicates that the element that the hx-target attribute is on is the target.
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-target/)

--- a/lsp/src/htmx/hx-trigger/changed.md
+++ b/lsp/src/htmx/hx-trigger/changed.md
@@ -1,0 +1,2 @@
+the event will only trigger if the value of the element has changed.
+Please pay attention `change` is the name of the event and changed is the name of the modifier.

--- a/lsp/src/htmx/hx-trigger/changed.md
+++ b/lsp/src/htmx/hx-trigger/changed.md
@@ -1,2 +1,5 @@
 the event will only trigger if the value of the element has changed.
 Please pay attention `change` is the name of the event and changed is the name of the modifier.
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/click.md
+++ b/lsp/src/htmx/hx-trigger/click.md
@@ -1,0 +1,1 @@
+trigger when the element is clicked with the cursor

--- a/lsp/src/htmx/hx-trigger/click.md
+++ b/lsp/src/htmx/hx-trigger/click.md
@@ -1,1 +1,4 @@
 trigger when the element is clicked with the cursor
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/consume.md
+++ b/lsp/src/htmx/hx-trigger/consume.md
@@ -1,0 +1,1 @@
+if this option is included the event will not trigger any other htmx requests on parents (or on elements listening on parents)

--- a/lsp/src/htmx/hx-trigger/consume.md
+++ b/lsp/src/htmx/hx-trigger/consume.md
@@ -1,1 +1,4 @@
 if this option is included the event will not trigger any other htmx requests on parents (or on elements listening on parents)
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/delay.md
+++ b/lsp/src/htmx/hx-trigger/delay.md
@@ -1,1 +1,4 @@
 delay:<timing declaration> - a delay will occur before an event triggers a request. If the event is seen again it will reset the delay.
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/delay.md
+++ b/lsp/src/htmx/hx-trigger/delay.md
@@ -1,0 +1,1 @@
+delay:<timing declaration> - a delay will occur before an event triggers a request. If the event is seen again it will reset the delay.

--- a/lsp/src/htmx/hx-trigger/every.md
+++ b/lsp/src/htmx/hx-trigger/every.md
@@ -1,0 +1,3 @@
+every <timing declaration> - can be used to have an element poll periodically.
+if you want to add a filter to polling, it should be added after the poll declaration:
+    `every 1s [someConditional]`

--- a/lsp/src/htmx/hx-trigger/every.md
+++ b/lsp/src/htmx/hx-trigger/every.md
@@ -1,3 +1,6 @@
 every <timing declaration> - can be used to have an element poll periodically.
 if you want to add a filter to polling, it should be added after the poll declaration:
     `every 1s [someConditional]`
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/from.md
+++ b/lsp/src/htmx/hx-trigger/from.md
@@ -1,0 +1,11 @@
+from:<Extended CSS selector> - allows the event that triggers a request to come from another element in the document (e.g. listening to a key event on the body, to support hot keys)
+
+A standard CSS selector resolves to all elements matching that selector.
+Thus, `from:input` would listen to every input on the page.
+
+The extended CSS selector here allows for the following non-standard CSS values:
+
+* `document` - listen for events on the document
+* `window` - listen for events on the window
+* `closest <CSS selector>` - finds the closest ancestor element or itself, matching the given css selector
+* `find <CSS selector>` - finds the closest child matching the given css selector

--- a/lsp/src/htmx/hx-trigger/from.md
+++ b/lsp/src/htmx/hx-trigger/from.md
@@ -9,3 +9,6 @@ The extended CSS selector here allows for the following non-standard CSS values:
 * `window` - listen for events on the window
 * `closest <CSS selector>` - finds the closest ancestor element or itself, matching the given css selector
 * `find <CSS selector>` - finds the closest child matching the given css selector
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/intersect.md
+++ b/lsp/src/htmx/hx-trigger/intersect.md
@@ -1,0 +1,5 @@
+fires once when an element first intersects the viewport. This supports two additional options:
+
+* root:<selector> - a CSS selector of the root element for intersection
+* threshold:<float> - a floating point number between 0.0 and 1.0, indicating what amount of intersection to fire the event on
+

--- a/lsp/src/htmx/hx-trigger/intersect.md
+++ b/lsp/src/htmx/hx-trigger/intersect.md
@@ -3,3 +3,6 @@ fires once when an element first intersects the viewport. This supports two addi
 * root:<selector> - a CSS selector of the root element for intersection
 * threshold:<float> - a floating point number between 0.0 and 1.0, indicating what amount of intersection to fire the event on
 
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/keyup.md
+++ b/lsp/src/htmx/hx-trigger/keyup.md
@@ -1,0 +1,1 @@
+keyup[key] - triggers when [key] is released, [key] can be omitted to trigger on any keyboard key

--- a/lsp/src/htmx/hx-trigger/keyup.md
+++ b/lsp/src/htmx/hx-trigger/keyup.md
@@ -1,1 +1,4 @@
 keyup[key] - triggers when [key] is released, [key] can be omitted to trigger on any keyboard key
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/load.md
+++ b/lsp/src/htmx/hx-trigger/load.md
@@ -1,0 +1,1 @@
+triggered on load (useful for lazy-loading something)

--- a/lsp/src/htmx/hx-trigger/load.md
+++ b/lsp/src/htmx/hx-trigger/load.md
@@ -1,1 +1,4 @@
 triggered on load (useful for lazy-loading something)
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/once.md
+++ b/lsp/src/htmx/hx-trigger/once.md
@@ -1,0 +1,1 @@
+the event will only trigger once (e.g. the first click)

--- a/lsp/src/htmx/hx-trigger/once.md
+++ b/lsp/src/htmx/hx-trigger/once.md
@@ -1,1 +1,4 @@
 the event will only trigger once (e.g. the first click)
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/queue.md
+++ b/lsp/src/htmx/hx-trigger/queue.md
@@ -1,0 +1,8 @@
+queue:<queue option> - determines how events are queued if an event occurs while a request for another event is in flight. Options are:
+
+* first - queue the first event
+* last - queue the last event (default)
+* all - queue all events (issue a request for each event)
+* none - do not queue new events
+
+

--- a/lsp/src/htmx/hx-trigger/queue.md
+++ b/lsp/src/htmx/hx-trigger/queue.md
@@ -6,3 +6,5 @@ queue:<queue option> - determines how events are queued if an event occurs while
 * none - do not queue new events
 
 
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/revealed.md
+++ b/lsp/src/htmx/hx-trigger/revealed.md
@@ -1,2 +1,5 @@
 triggered when an element is scrolled into the viewport (also useful for lazy-loading).
 If you are using overflow in css like overflow-y: scroll you should use intersect once instead of revealed.
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/revealed.md
+++ b/lsp/src/htmx/hx-trigger/revealed.md
@@ -1,0 +1,2 @@
+triggered when an element is scrolled into the viewport (also useful for lazy-loading).
+If you are using overflow in css like overflow-y: scroll you should use intersect once instead of revealed.

--- a/lsp/src/htmx/hx-trigger/target.md
+++ b/lsp/src/htmx/hx-trigger/target.md
@@ -1,0 +1,2 @@
+target:<CSS selector> - allows you to filter via a CSS selector on the target of the event.
+This can be useful when you want to listen for triggers from elements that might not be in the DOM at the point of initialization, by, for example, listening on the body, but with a target filter for a child element.

--- a/lsp/src/htmx/hx-trigger/target.md
+++ b/lsp/src/htmx/hx-trigger/target.md
@@ -1,2 +1,5 @@
 target:<CSS selector> - allows you to filter via a CSS selector on the target of the event.
 This can be useful when you want to listen for triggers from elements that might not be in the DOM at the point of initialization, by, for example, listening on the body, but with a target filter for a child element.
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/throttle.md
+++ b/lsp/src/htmx/hx-trigger/throttle.md
@@ -1,2 +1,6 @@
 throttle:<timing declaration> - a throttle will occur after an event triggers a request.
 If the event is seen again before the delay completes, it is ignored, the element will trigger at the end of the delay.
+
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-trigger/)

--- a/lsp/src/htmx/hx-trigger/throttle.md
+++ b/lsp/src/htmx/hx-trigger/throttle.md
@@ -1,0 +1,2 @@
+throttle:<timing declaration> - a throttle will occur after an event triggers a request.
+If the event is seen again before the delay completes, it is ignored, the element will trigger at the end of the delay.

--- a/lsp/src/htmx/mod.rs
+++ b/lsp/src/htmx/mod.rs
@@ -71,11 +71,6 @@ fn to_hx_completion(values: Vec<(&str, &str)>) -> Vec<HxCompletion> {
 pub fn init_hx_tags() {
     _ = HX_ATTRIBUTE_VALUES.set(
         maplit::hashmap!{
-            String::from("hx-boost") => to_hx_completion(vec![
-                ("true", ""),
-                ("false", ""),
-            ]),
-
             String::from("hx-swap") => to_hx_completion(vec![
                 ("innerHTML", include_str!("./hx-swap/innerHTML.md")),
                 ("outerHTML", include_str!("./hx-swap/outerHTML.md")),

--- a/lsp/src/htmx/mod.rs
+++ b/lsp/src/htmx/mod.rs
@@ -95,6 +95,11 @@ pub fn init_hx_tags() {
                 ("this", include_str!("./hx-target/this.md")),
             ]),
 
+            String::from("hx-boost") => to_hx_completion(vec![
+                ("true", include_str!("./hx-boost/true.md")),
+                ("false", include_str!("./hx-boost/false.md")),
+            ]),
+
             String::from("hx-trigger") => to_hx_completion(vec![
                 ("click", include_str!("./hx-trigger/click.md")),
                 ("once", include_str!("./hx-trigger/once.md")),

--- a/lsp/src/htmx/mod.rs
+++ b/lsp/src/htmx/mod.rs
@@ -159,6 +159,23 @@ pub fn init_hx_tags() {
             ("hx-push-url", include_str!("./attributes/hx-push-url.md")),
             ("hx-select", include_str!("./attributes/hx-select.md")),
             ("hx-ext", include_str!("./attributes/hx-ext.md")),
+            ("hx-on", include_str!("./attributes/hx-on.md")),
+            ("hx-select-oob", include_str!("./attributes/hx-select-oob.md")),
+            ("hx-swap-oob", include_str!("./attributes/hx-swap-oob.md")),
+            ("hx-confirm", include_str!("./attributes/hx-confirm.md")),
+            ("hx-disable", include_str!("./attributes/hx-disable.md")),
+            ("hx-encoding", include_str!("./attributes/hx-encoding.md")),
+            ("hx-headers", include_str!("./attributes/hx-headers.md")),
+            ("hx-history", include_str!("./attributes/hx-history.md")),
+            ("hx-history-elt", include_str!("./attributes/hx-history-elt.md")),
+            ("hx-indicator", include_str!("./attributes/hx-indicator.md")),
+            ("hx-params", include_str!("./attributes/hx-params.md")),
+            ("hx-preserve", include_str!("./attributes/hx-preserve.md")),
+            ("hx-prompt", include_str!("./attributes/hx-prompt.md")),
+            ("hx-replace-url", include_str!("./attributes/hx-replace-url.md")),
+            ("hx-request", include_str!("./attributes/hx-request.md")),
+            ("hx-sync", include_str!("./attributes/hx-sync.md")),
+            ("hx-validate", include_str!("./attributes/hx-validate.md")),
         ])
     );
 }

--- a/lsp/src/htmx/mod.rs
+++ b/lsp/src/htmx/mod.rs
@@ -94,6 +94,23 @@ pub fn init_hx_tags() {
                 ("prev", include_str!("./hx-target/prev.md")),
                 ("this", include_str!("./hx-target/this.md")),
             ]),
+
+            String::from("hx-trigger") => to_hx_completion(vec![
+                ("click", include_str!("./hx-trigger/click.md")),
+                ("once", include_str!("./hx-trigger/once.md")),
+                ("changed", include_str!("./hx-trigger/changed.md")),
+                ("delay:", include_str!("./hx-trigger/delay.md")),
+                ("throttle:", include_str!("./hx-trigger/throttle.md")),
+                ("from:", include_str!("./hx-trigger/from.md")),
+                ("target:", include_str!("./hx-trigger/target.md")),
+                ("consume", include_str!("./hx-trigger/consume.md")),
+                ("queue:", include_str!("./hx-trigger/queue.md")),
+                ("keyup", include_str!("./hx-trigger/keyup.md")),
+                ("load", include_str!("./hx-trigger/load.md")),
+                ("revealed", include_str!("./hx-trigger/revealed.md")),
+                ("intersect", include_str!("./hx-trigger/intersect.md")),
+                ("every", include_str!("./hx-trigger/every.md")),
+            ])
         });
 
     _ = HX_TAGS.set(

--- a/lsp/src/htmx/mod.rs
+++ b/lsp/src/htmx/mod.rs
@@ -115,6 +115,31 @@ pub fn init_hx_tags() {
                 ("revealed", include_str!("./hx-trigger/revealed.md")),
                 ("intersect", include_str!("./hx-trigger/intersect.md")),
                 ("every", include_str!("./hx-trigger/every.md")),
+            ]),
+
+            String::from("hx-ext") => to_hx_completion(vec![
+                ("ajax-header", include_str!("./hx-ext/ajax-header.md")),
+                ("alpine-morph", include_str!("./hx-ext/alpine-morph.md")),
+                ("class-tools", include_str!("./hx-ext/class-tools.md")),
+                ("client-side-templates", include_str!("./hx-ext/client-side-templates.md")),
+                ("debug", include_str!("./hx-ext/debug.md")),
+                ("disable-element", include_str!("./hx-ext/disable-element.md")),
+                ("event-header", include_str!("./hx-ext/event-header.md")),
+                ("head-support", include_str!("./hx-ext/head-support.md")),
+                ("include-vals", include_str!("./hx-ext/include-vals.md")),
+                ("json-enc", include_str!("./hx-ext/json-enc.md")),
+                ("morph", include_str!("./hx-ext/morph.md")),
+                ("loading-states", include_str!("./hx-ext/loading-states.md")),
+                ("method-override", include_str!("./hx-ext/method-override.md")),
+                ("morphdom-swap", include_str!("./hx-ext/morphdom-swap.md")),
+                ("multi-swap", include_str!("./hx-ext/multi-swap.md")),
+                ("path-deps", include_str!("./hx-ext/path-deps.md")),
+                ("preload", include_str!("./hx-ext/preload.md")),
+                ("remove-me", include_str!("./hx-ext/remove-me.md")),
+                ("response-targets", include_str!("./hx-ext/response-targets.md")),
+                ("restored", include_str!("./hx-ext/restored.md")),
+                ("sse", include_str!("./hx-ext/sse.md")),
+                ("ws", include_str!("./hx-ext/ws.md")),
             ])
         });
 
@@ -133,6 +158,7 @@ pub fn init_hx_tags() {
             ("hx-vals", include_str!("./attributes/hx-vals.md")),
             ("hx-push-url", include_str!("./attributes/hx-push-url.md")),
             ("hx-select", include_str!("./attributes/hx-select.md")),
+            ("hx-ext", include_str!("./attributes/hx-ext.md")),
         ])
     );
 }

--- a/lsp/src/htmx/mod.rs
+++ b/lsp/src/htmx/mod.rs
@@ -135,6 +135,45 @@ pub fn init_hx_tags() {
                 ("restored", include_str!("./hx-ext/restored.md")),
                 ("sse", include_str!("./hx-ext/sse.md")),
                 ("ws", include_str!("./hx-ext/ws.md")),
+            ]),
+
+            String::from("hx-push-url") => to_hx_completion(vec![
+                ("true", include_str!("./hx-push-url/true.md")),
+                ("false", include_str!("./hx-push-url/false.md")),
+            ]),
+
+            String::from("hx-swap-oob") => to_hx_completion(vec![
+                ("true", include_str!("./hx-swap-oob/true.md")),
+                ("innerHTML", include_str!("./hx-swap/innerHTML.md")),
+                ("outerHTML", include_str!("./hx-swap/outerHTML.md")),
+                ("afterbegin", include_str!("./hx-swap/afterbegin.md")),
+                ("afterend", include_str!("./hx-swap/afterend.md")),
+                ("beforebegin", include_str!("./hx-swap/beforebegin.md")),
+                ("beforeend", include_str!("./hx-swap/beforeend.md")),
+                ("delete", include_str!("./hx-swap/delete.md")),
+                ("none", include_str!("./hx-swap/none.md")),
+            ]),
+
+            String::from("hx-history") => to_hx_completion(vec![
+                ("false", include_str!("./hx-history/false.md")),
+            ]),
+
+            String::from("hx-params") => to_hx_completion(vec![
+                ("*", include_str!("./hx-params/star.md")),
+                ("none", include_str!("./hx-params/none.md")),
+                ("not", include_str!("./hx-params/not.md")),
+            ]),
+
+            String::from("hx-replace-url") => to_hx_completion(vec![
+                ("true", include_str!("./hx-replace-url/true.md")),
+                ("false", include_str!("./hx-replace-url/false.md")),
+            ]),
+
+            String::from("hx-sync") => to_hx_completion(vec![
+                ("drop", include_str!("./hx-sync/drop.md")),
+                ("abort", include_str!("./hx-sync/abort.md")),
+                ("replace", include_str!("./hx-sync/replace.md")),
+                ("queue", include_str!("./hx-sync/queue.md")),
             ])
         });
 


### PR DESCRIPTION
Adding attribute completions for the hx-trigger and hx-boost tags.

I used the documentation on htmx.org where it was applicable.
I did spot a typo in the documentation which I fixed.
For the attributes that did not have a relevant entry in the documentation I wrote some simple explanation myself.