### PR TITLE
feat: use treesitter Query for building Positions

### DIFF
--- a/lsp/src/tree_sitter.rs
+++ b/lsp/src/tree_sitter.rs
@@ -1,6 +1,7 @@
 use log::error;
 use lsp_types::TextDocumentPositionParams;
-use tree_sitter::{Node, Parser, Point};
+use std::collections::HashMap;
+use tree_sitter::{Node, Parser, Point, Query, QueryCursor};
 
 use crate::text_store::get_text_document;
 
@@ -53,26 +54,131 @@ fn create_attribute(node: Node<'_>, source: &str) -> Option<Position> {
         }
         _ => {}
     };
-    return None
+    return None;
+}
+
+fn get_position_by_query(query: &str, node: Node<'_>, source: &str) -> Option<Position> {
+    let query = Query::new(tree_sitter_html::language(), query).unwrap();
+
+    let mut cursor = QueryCursor::new();
+    let matches = cursor.matches(&query, node, source.as_bytes());
+
+    println!("-- node {:?}", node.to_sexp());
+
+    let formatted = matches
+        .map(|m| {
+            println!("--!!!! match {:?}", m);
+            let mut values: HashMap<String, String> = HashMap::new();
+            let captures = m.captures;
+            println!("---- << captures {:?}", captures.to_vec());
+            for capture in captures.iter() {
+                println!("-- << capture {:?}", capture);
+                let capture_name = query.capture_names()[capture.index as usize].as_str();
+                println!("-- << capture_name {:?}", capture_name);
+
+                let value = capture
+                    .node
+                    .utf8_text(source.as_bytes())
+                    .unwrap()
+                    .to_string();
+
+                values.insert(capture_name.to_string(), value);
+            }
+            println!("-- << values {:?}", values);
+            values
+        })
+        .map(|v| match v.get("attr_value") {
+            Some(value) => Some(Position::AttributeValue {
+                name: format!("{}", "attr_name"),
+                value: format!("{}", value),
+            }),
+            None => match v.get("attr_name") {
+                Some(name) => Some(Position::AttributeName(format!("{}", name))),
+                None => None,
+            },
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    return formatted.first()?.clone();
+}
+
+fn find_start_tag_node(node: Node<'_>) -> Option<Node<'_>> {
+    println!("-- node {:?}", node.to_sexp());
+    if node.kind() == "element" || node.kind() == "fragment" {
+        return Some(node.child(0)?);
+    }
+
+    let parent = node.parent()?;
+
+    if parent.kind() == "element" {
+        return Some(node);
+    }
+
+    if node.kind() == "ERROR" {
+        return Some(node);
+    }
+
+    return find_start_tag_node(parent);
+}
+
+fn query_position(root: Node<'_>, source: &str, row: usize, column: usize) -> Option<Position> {
+    error!("get_position");
+
+    println!("-- root {:?}", root.to_sexp());
+    let desc = root.descendant_for_point_range(Point { row, column }, Point { row, column })?;
+    println!("-- desc {:?}", desc.to_sexp());
+    let node = find_start_tag_node(desc)?;
+    println!("------ FOUND node {:?}", node.to_sexp());
+
+    if node.kind() == "ERROR" {
+        return get_position_by_query(
+            r#"
+    (
+        (ERROR 
+            (tag_name)
+            (attribute_name) @attr_name
+        )
+        (#match? @attr_name "hx-.*?")
+    )
+    "#,
+            node,
+            source,
+        );
+    }
+
+    return get_position_by_query(
+        r#"
+    (
+        (start_tag 
+            (tag_name)
+            (attribute (attribute_name) @attr_name
+                (quoted_attribute_value 
+                    (attribute_value)? @attr_value
+                )? @quoted_attr_value
+            )
+        ) @tag
+        (#match? @attr_name "hx-.*?")
+    )
+"#,
+        node,
+        source,
+    );
 }
 
 fn get_position(root: Node<'_>, source: &str, row: usize, column: usize) -> Option<Position> {
     error!("get_position");
 
-    let desc = root.descendant_for_point_range(
-        Point { row, column },
-        Point { row, column },
-    )?;
+    let desc = root.descendant_for_point_range(Point { row, column }, Point { row, column })?;
 
     error!("get_position: desc {:?}", desc);
 
-    return create_attribute(desc, source)
+    return create_attribute(desc, source);
 }
 
 pub fn get_position_from_lsp_completion(
     text_params: TextDocumentPositionParams,
 ) -> Option<Position> {
-
     error!("get_position_from_lsp_completion");
     let text = get_text_document(text_params.text_document.uri)?;
     error!("get_position_from_lsp_completion: text {}", text);
@@ -95,4 +201,156 @@ pub fn get_position_from_lsp_completion(
         pos.line as usize,
         pos.character as usize,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_position, query_position, Position};
+    use tree_sitter::{Parser, Point, Query, QueryCursor};
+
+    #[test]
+    fn test_it_matches_when_starting_tag() {
+        let text = r##"<div hx- ></div>"##;
+        let language = tree_sitter_html::language();
+        let mut parser = Parser::new();
+
+        parser
+            .set_language(language)
+            .expect("could not load html grammer");
+        let tree = parser.parse(&text, None).expect("not to fail");
+        let matches = query_position(tree.root_node(), text, 0, 4);
+
+        assert_eq!(matches, Some(Position::AttributeName("hx-".to_string())));
+    }
+
+    #[test]
+    fn test_it_matches_when_completing_with_values() {
+        let text = r##"<div hx-swap=></div>"##;
+        let language = tree_sitter_html::language();
+        let mut parser = Parser::new();
+
+        parser
+            .set_language(language)
+            .expect("could not load html grammer");
+        let tree = parser.parse(&text, None).expect("not to fail");
+        let matches = query_position(tree.root_node(), text, 0, 13);
+
+        assert_eq!(
+            matches,
+            Some(Position::AttributeName("hx-swap".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_it_matches_when_starting_quote_value() {
+        let text = r##"<div hx-swap="></div>"##;
+        let language = tree_sitter_html::language();
+        let mut parser = Parser::new();
+
+        parser
+            .set_language(language)
+            .expect("could not load html grammer");
+        let tree = parser.parse(&text, None).expect("not to fail");
+        let matches = get_position(tree.root_node(), text, 0, 14);
+
+        assert_eq!(
+            matches,
+            Some(Position::AttributeValue {
+                name: "hx-swap".to_string(),
+                value: "></div>".to_string()
+            })
+        );
+    }
+    //
+    // #[test]
+    // fn test_it_matches_when_open_and_closed_quotes() {
+    //     let text = r##"<div hx-swap=""></div>"##;
+    //     let language = tree_sitter_html::language();
+    //     let mut parser = Parser::new();
+    //
+    //     parser
+    //         .set_language(language)
+    //         .expect("could not load html grammer");
+    //     let tree = parser.parse(&text, None).expect("not to fail");
+    //     let matches = query_position(tree.root_node(), text, 0, 14);
+    //
+    //     assert_eq!(
+    //         matches,
+    //         Some(Position::AttributeValue {
+    //             name: "hx-swap".to_string(),
+    //             value: "\"\"".to_string()
+    //         })
+    //     );
+    // }
+    //
+    // #[test]
+    // fn test_it_matches_a_unclosed_tag_in_the_middle() {
+    //     let text = r##"<div id="fa" hx-swap="hx-swap" hx-swap="hx-swap">
+    //   <span hx-swap="
+    //   <button>Click me</button>
+    // </div>
+    // "##;
+    //     let language = tree_sitter_html::language();
+    //     let mut parser = Parser::new();
+    //
+    //     parser
+    //         .set_language(language)
+    //         .expect("could not load html grammer");
+    //     let tree = parser.parse(&text, None).expect("not to fail");
+    //     let matches = query_position(tree.root_node(), text, 1, 17);
+    //
+    //     assert_eq!(
+    //         matches,
+    //         Some(Position::AttributeValue {
+    //             name: "hx-swap".to_string(),
+    //             value: "\n  <button>Click me</button>\n</div>\n".to_string()
+    //         })
+    //     );
+    // }
+    //
+    // #[test]
+    // fn test_error() {
+    //     let text = r##"<div hx-"##;
+    //     let language = tree_sitter_html::language();
+    //     let mut parser = Parser::new();
+    //
+    //     parser
+    //         .set_language(language)
+    //         .expect("could not load html grammer");
+    //     let tree = parser.parse(&text, None).expect("not to fail");
+    //     let matches = query_position(tree.root_node(), text, 1, 7);
+    //
+    //     assert_eq!(
+    //         matches,
+    //         Some(Position::AttributeValue {
+    //             name: "hx-swap".to_string(),
+    //             value: "\n  <button>Click me</button>\n</div>\n".to_string()
+    //         })
+    //     );
+    // }
+    //
+    //     #[test]
+    //     fn test_it_matches_a_unclosed_tag_in_the_middle_() {
+    //         let text = r##"<div id="fa" hx-swap="hx-swap" hx-swap="hx-swap">
+    //   <span hx-
+    //   <tebutton>Click me</button>
+    // </div>
+    // "##;
+    //         let language = tree_sitter_html::language();
+    //         let mut parser = Parser::new();
+    //
+    //         parser
+    //             .set_language(language)
+    //             .expect("could not load html grammer");
+    //         let tree = parser.parse(&text, None).expect("not to fail");
+    //         let matches = query_position(tree.root_node(), text, 1, 11);
+    //
+    //         assert_eq!(
+    //             matches,
+    //             Some(Position::AttributeValue {
+    //                 name: "hx-swap".to_string(),
+    //                 value: "\n  <tebutton>Click me</button>\n</div>\n".to_string()
+    //             })
+    //         );
+    //     }
 }


### PR DESCRIPTION
Playing with the tree-sitter is quite fun :) 

I figured tree-sitter comes with a built-in query feature, I'm not sure it is more performant than the current implementation, I didn't test it, but I'd place my bet on that.

I used this for reference:
https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries

Also their unit tests https://github.com/tree-sitter/tree-sitter/blob/master/cli/src/tests/query_test.rs

I didn't remove the dead code, I just kept it as a comparison, but accordingly with the tests they are behaving the same, this implementation also the fix in #12

This implementation doesn't address the suggesting when editing an attribute in the middle of other hx-*
For instance: 
```html
<div hx-get="/foo" hx-target="<cursor here> hx-swap="next"></div>
```