### PR TITLE
refactor: use bail before stringifying name

### DIFF
--- a/lsp/src/htmx/mod.rs
+++ b/lsp/src/htmx/mod.rs
@@ -31,14 +31,13 @@ impl TryFrom<&(PathBuf, String)> for HxCompletion {
     type Error = anyhow::Error;
 
     fn try_from((path, desc): &(PathBuf, String)) -> Result<Self, Self::Error> {
-        let name = path.to_str().unwrap_or("").to_string();
-        if name == "" {
-            return Err(anyhow::anyhow!("Invalid path"));
+        match path.to_str() {
+            None | Some("") => anyhow::bail!("Invalid path"),
+            Some(name) => Ok(Self {
+                name: name.to_string(),
+                desc: desc.to_string(),
+            }),
         }
-        return Ok(Self {
-            name,
-            desc: desc.to_string(),
-        });
     }
 }
 


### PR DESCRIPTION
This is a rather simple refactor. When the `.to_str()` on the path returns a `None` or some empty string, we use `anyhow::bail` to bail out of the function instead of using a default value and stringifying it. For any other values, the code goes the happy path.