### PR TITLE
Binary distribution: Use Github API to get `OLD_VERSION`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
         shell: bash
         run: |
           RELEASE_VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/["]/, "", $2); printf("%s",$2) }' Cargo.toml)
-          OLD_VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/["]/, "", $2); printf("%s",$2) }' <<< "$(git show HEAD~1:Cargo.toml)")
+          OLD_VERSION=$(curl "https://api.github.com/repos/ThePrimeagen/htmx-lsp/releases/latest" | grep "tag_name" | cut -d'"' -f4)
 
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,11 +91,16 @@ jobs:
         shell: bash
         run: |
           RELEASE_VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/["]/, "", $2); printf("%s",$2) }' Cargo.toml)
-          OLD_VERSION=$(curl "https://api.github.com/repos/ThePrimeagen/htmx-lsp/releases/latest" | grep "tag_name" | cut -d'"' -f4)
+          latest=$(curl https://api.github.com/repos/ThePrimeagen/htmx-lsp/releases/latest)
+
+          # no releases, default to 0.0.0
+          if [[ "$latest" == *"Not Found"* ]]; then
+              OLD_VERSION="0.0.0"
+          else
+              OLD_VERSION=$( echo $latest | grep "tag_name" | cut -d'"' -f4 )
+          fi
 
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-
-
           echo "$OLD_VERSION -> $RELEASE_VERSION"
 
           if [[ "$RELEASE_VERSION" == "$OLD_VERSION" ]]; then


### PR DESCRIPTION
This makes the release mechanism a little less brittle, uses the Github API to get the last released version, instead of the last commit. Also added a condition for handling no releases, so merging his will release `0.1.0`. 

Tested here: https://github.com/praveenperera/htmx-lsp/releases/tag/0.1.0

I usually release rust binaries a little differently, I use cross to release for more targets and upload the `tar.gz` (linux, macOS) or `.zip` (windows) instead of the binary directly. Which makes for slightly smaller downloads.

See: https://github.com/avencera/rustywind/releases/tag/v0.19.0

If you prefer that way I can just bring the GitHub action over that I used there.



