### PR TITLE
[CI] Fix ci by updating lockfile & deduping action runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,36 +1,35 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
 
 jobs:
   clippy:
+    name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            components: clippy
-            override: true
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-      - run: cargo clippy -- -D warnings
+      - name: Setup Rust env
+        uses: ./.github/actions/setup-rust-env
+
+      - name: Rust clippy
+        run: cargo clippy -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-      - name: Install stable toolchain with rustfmt available
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt
+      - name: Setup Rust env
+        uses: ./.github/actions/setup-rust-env
 
-      - run: cargo fmt --check
+      - name: Rust fmt
+        run: cargo fmt --check
 
   test:
     name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,12 +81,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Download binaries
-        uses: actions/download-artifact@v3
-        with:
-          name: built-binaries
-          path: bin
-
       - name: Check if release should be created
         shell: bash
         run: |
@@ -110,6 +104,14 @@ jobs:
             git push -u origin "$RELEASE_VERSION"
             echo "SHOULD_RELEASE=yes" >> $GITHUB_ENV
           fi
+
+
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        if: env.SHOULD_RELEASE == 'yes'
+        with:
+          name: built-binaries
+          path: bin
 
       - name: Publish release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Build & Release
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "max/fix-ci"]
 
 permissions:
   contents: write
@@ -74,7 +74,7 @@ jobs:
     name: Release
     runs-on: ubuntu-22.04
     needs: build
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/DOESNOTEXIST'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Build & Release
 
 on:
   push:
-    branches: ["master", "max/fix-ci"]
+    branches: ["master"]
 
 permissions:
   contents: write
@@ -74,7 +74,7 @@ jobs:
     name: Release
     runs-on: ubuntu-22.04
     needs: build
-    if: github.ref == 'refs/heads/DOESNOTEXIST'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -104,7 +104,6 @@ jobs:
             git push -u origin "$RELEASE_VERSION"
             echo "SHOULD_RELEASE=yes" >> $GITHUB_ENV
           fi
-
 
       - name: Download binaries
         uses: actions/download-artifact@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,6 @@ name = "htmx-lsp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cc",
  "clap",
  "htmx-lsp-server",
  "htmx-lsp-util",


### PR DESCRIPTION
Both the `Build & Release` & `CI` workflows are broken:
- `B&R`: The most recent lockfile wasn't committed, which `cargo` gets mad at since its out of date (bad @ThePrimeagen)
- `CI`: It was being triggered twice, once for the `push` event and once for the `pull_request` the push was associated with. Let's dedup this (which was also causing the cargo clippy actions errors somehow)