### PR TITLE
Cleanups for clippy and text_store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: ./.github/actions/setup-rust-env
 
       - name: Rust clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy -- -Dclippy::all -D warnings
 
   rustfmt:
     name: Format

--- a/lsp/src/handle.rs
+++ b/lsp/src/handle.rs
@@ -74,7 +74,6 @@ fn handle_didChange(noti: Notification) -> Option<HtmxResult> {
         .expect("text store not initialized")
         .lock()
         .expect("text store mutex poisoned")
-        .texts
         .insert(uri, text);
 
     None
@@ -96,11 +95,7 @@ fn handle_didOpen(noti: Notification) -> Option<HtmxResult> {
         .expect("text store not initialized")
         .lock()
         .expect("text store mutex poisoned")
-        .texts
-        .insert(
-            text_document_changes.uri,
-            text_document_changes.text.to_string(),
-        );
+        .insert(text_document_changes.uri, text_document_changes.text);
 
     None
 }
@@ -210,7 +205,6 @@ mod tests {
             .expect("text store not initialized")
             .lock()
             .expect("text store mutex poisoned")
-            .texts
             .insert(file.to_string(), content.to_string());
     }
 

--- a/lsp/src/htmx/mod.rs
+++ b/lsp/src/htmx/mod.rs
@@ -62,7 +62,7 @@ pub fn hx_completion(text_params: TextDocumentPositionParams) -> Option<Vec<HxCo
 }
 
 pub fn hx_hover(text_params: TextDocumentPositionParams) -> Option<HxCompletion> {
-    let result = crate::tree_sitter::get_position_from_lsp_completion(text_params.clone())?;
+    let result = crate::tree_sitter::get_position_from_lsp_completion(text_params)?;
     debug!("handle_hover result: {:?}", result);
 
     match result {

--- a/lsp/src/text_store.rs
+++ b/lsp/src/text_store.rs
@@ -1,28 +1,40 @@
 use std::{
     collections::HashMap,
+    ops::{Deref, DerefMut},
     sync::{Arc, Mutex, OnceLock},
 };
 
 use lsp_types::Url;
 
-pub struct TextStore {
-    pub texts: HashMap<String, String>,
+type TxtStore = HashMap<String, String>;
+
+pub struct TextStore(TxtStore);
+
+impl Deref for TextStore {
+    type Target = TxtStore;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for TextStore {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 pub static TEXT_STORE: OnceLock<Arc<Mutex<TextStore>>> = OnceLock::new();
+
 pub fn init_text_store() {
-    _ = TEXT_STORE.set(Arc::new(Mutex::new(TextStore {
-        texts: HashMap::new(),
-    })));
+    _ = TEXT_STORE.set(Arc::new(Mutex::new(TextStore(HashMap::new()))));
 }
 
 pub fn get_text_document(uri: Url) -> Option<String> {
-    return TEXT_STORE
+    TEXT_STORE
         .get()
         .expect("text store not initialized")
         .lock()
         .expect("text store mutex poisoned")
-        .texts
         .get(&uri.to_string())
-        .cloned();
+        .cloned()
 }


### PR DESCRIPTION
Summary
----
- The most notable change here is the removal of unnecessary clones as suggested by clippy. Furthermore, this also makes the TextStore a wrapper type of a `HashMap<String, String>` and implements Deref and DerefMut for it.

- Workflow update to ensure that clippy runs in _more_ exhaustive way (this is actually how I found about the unnecessary cloning).