### PR TITLE
Add hx-disabled-elt attribute

### DIFF
--- a/lsp/src/htmx/attributes/hx-disabled-elt.md
+++ b/lsp/src/htmx/attributes/hx-disabled-elt.md
@@ -1,0 +1,17 @@
+The hx-disabled-elt attribute allows you to specify elements that will have the disabled attribute added to them for the duration of the request.
+
+The value of this attribute is a CSS query selector of the element or elements to apply the class to, or the keyword closest, followed by a CSS selector, which will find the closest ancestor element or itself, that matches the given CSS selector (e.g. closest tr), or the keyword this.
+
+Here is an example with a button that will disable itself during a request:
+
+<button hx-post="/example" hx-disabled-elt="this">
+    Post It!
+</button>
+
+When a request is in flight, this will cause the button to be marked with the disabled attribute, which will prevent further clicks from occurring.
+
+Notes
+
+    hx-disable-elt is inherited and can be placed on a parent element
+
+[HTMX reference](https://htmx.org/attributes/hx-disabled-elt/)

--- a/lsp/src/htmx/hx-disabled-elt/closest.md
+++ b/lsp/src/htmx/hx-disabled-elt/closest.md
@@ -1,0 +1,4 @@
+closest <CSS selector> which will find the closest ancestor element or itself, that matches the given CSS selector (e.g. closest tr will target the closest table row to the element).
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-disabled-elt/)

--- a/lsp/src/htmx/hx-disabled-elt/this.md
+++ b/lsp/src/htmx/hx-disabled-elt/this.md
@@ -1,0 +1,4 @@
+this which indicates that the element that the hx-disabled-elt attribute is on is the target.
+
+
+[HTMX Reference](https://htmx.org/attributes/hx-disabled-elt/)

--- a/lsp/src/htmx/mod.rs
+++ b/lsp/src/htmx/mod.rs
@@ -115,6 +115,11 @@ pub fn init_hx_tags() {
             ("false", include_str!("./hx-boost/false.md")),
         ]),
 
+        String::from("hx-disabled-elt") => to_hx_completion(vec![
+            ("closest", include_str!("./hx-disabled-elt/closest.md")),
+            ("this", include_str!("./hx-disabled-elt/this.md")),
+        ]),
+
         String::from("hx-trigger") => to_hx_completion(vec![
             ("click", include_str!("./hx-trigger/click.md")),
             ("once", include_str!("./hx-trigger/once.md")),
@@ -220,6 +225,10 @@ pub fn init_hx_tags() {
         ("hx-swap-oob", include_str!("./attributes/hx-swap-oob.md")),
         ("hx-confirm", include_str!("./attributes/hx-confirm.md")),
         ("hx-disable", include_str!("./attributes/hx-disable.md")),
+        (
+            "hx-disabled-elt",
+            include_str!("./attributes/hx-disabled-elt.md"),
+        ),
         ("hx-encoding", include_str!("./attributes/hx-encoding.md")),
         ("hx-headers", include_str!("./attributes/hx-headers.md")),
         ("hx-history", include_str!("./attributes/hx-history.md")),


### PR DESCRIPTION
Htmx 1.9.6 introduced this attribute, used to be an extension ([source](https://github.com/bigskysoftware/htmx/blob/c538c65a4b19fb0ac0b4fcf2487eff61a0624f06/www/content/posts/2023-09-22-htmx-1.9.6-is-released.md?plain=1#L15)).  
https://htmx.org/attributes/hx-disabled-elt/

Not sure if I should state somewhere that it's only available from 1.9.6? Might be some folks running an older version and may cause confusion. Let me know!