### PR TITLE
Improve hover support

### DIFF
--- a/lsp/src/handle.rs
+++ b/lsp/src/handle.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use log::{debug, error, warn};
 use lsp_server::{Message, Notification, Request, RequestId};
-use lsp_types::{CompletionContext, CompletionParams, CompletionTriggerKind};
+use lsp_types::{CompletionContext, CompletionParams, CompletionTriggerKind, HoverParams};
 
 #[derive(serde::Deserialize, Debug)]
 struct Text {
@@ -141,12 +141,12 @@ fn handle_completion(req: Request) -> Option<HtmxResult> {
 }
 
 fn handle_hover(req: Request) -> Option<HtmxResult> {
-    let completion: CompletionParams = serde_json::from_value(req.params).ok()?;
-    debug!("handle_hover: {:?}", completion.context);
+    let hover: HoverParams = serde_json::from_value(req.params).ok()?;
+    debug!("handle_hover: {:?}", hover);
 
-    let text_params = completion.text_document_position;
+    let text_params = hover.text_document_position_params;
 
-    debug!("handle_hover text_params: {:?}", text_params);
+    debug!("handle_hover text_position_params: {:?}", text_params);
 
     let attribute = hx_hover(text_params)?;
 

--- a/lsp/src/lib.rs
+++ b/lsp/src/lib.rs
@@ -9,8 +9,8 @@ use htmx::HxCompletion;
 use log::{debug, error, info, warn};
 use lsp_types::{
     CompletionItem, CompletionItemKind, CompletionList, HoverContents, InitializeParams,
-    LanguageString, MarkedString, ServerCapabilities, TextDocumentSyncCapability,
-    TextDocumentSyncKind, WorkDoneProgressOptions,
+    MarkupContent, ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind,
+    WorkDoneProgressOptions,
 };
 
 use lsp_server::{Connection, Message, Response};
@@ -80,10 +80,10 @@ fn main_loop(connection: Connection, params: serde_json::Value) -> Result<()> {
             Some(HtmxResult::AttributeHover(hover_resp)) => {
                 debug!("main_loop - hover response: {:?}", hover_resp);
                 let hover_response = lsp_types::Hover {
-                    contents: HoverContents::Scalar(MarkedString::LanguageString(LanguageString {
-                        language: "html".to_string(),
-                        value: hover_resp.value.clone(),
-                    })),
+                    contents: HoverContents::Markup(MarkupContent {
+                        kind: lsp_types::MarkupKind::Markdown,
+                        value: hover_resp.value.to_string(),
+                    }),
                     range: None,
                 };
 

--- a/lsp/src/text_store.rs
+++ b/lsp/src/text_store.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex, OnceLock},
 };
 
-use lsp_types::Url;
+use lsp_types::{TextDocumentPositionParams, Url};
 
 type TxtStore = HashMap<String, String>;
 
@@ -29,7 +29,7 @@ pub fn init_text_store() {
     _ = TEXT_STORE.set(Arc::new(Mutex::new(TextStore(HashMap::new()))));
 }
 
-pub fn get_text_document(uri: Url) -> Option<String> {
+pub fn get_text_document(uri: &Url) -> Option<String> {
     return TEXT_STORE
         .get()
         .expect("text store not initialized")
@@ -37,4 +37,54 @@ pub fn get_text_document(uri: Url) -> Option<String> {
         .expect("text store mutex poisoned")
         .get(&uri.to_string())
         .cloned();
+}
+
+/// Find the start and end indices of a word inside the given line
+/// Borrowed from RLS
+fn find_word_at_pos(line: &str, col: usize) -> (usize, usize) {
+    let line_ = format!("{} ", line);
+    let is_ident_char = |c: char| c.is_alphanumeric() || c == '_' || c == '-';
+
+    let start = line_
+        .chars()
+        .enumerate()
+        .take(col)
+        .filter(|&(_, c)| !is_ident_char(c))
+        .last()
+        .map(|(i, _)| i + 1)
+        .unwrap_or(0);
+
+    #[allow(clippy::filter_next)]
+    let mut end = line_
+        .chars()
+        .enumerate()
+        .skip(col)
+        .filter(|&(_, c)| !is_ident_char(c));
+
+    let end = end.next();
+    (start, end.map(|(i, _)| i).unwrap_or(col))
+}
+
+pub fn get_word_from_pos_params(pos_params: &TextDocumentPositionParams) -> anyhow::Result<String> {
+    let uri = &pos_params.text_document.uri;
+    let line = pos_params.position.line as usize;
+    let col = pos_params.position.character as usize;
+
+    match get_text_document(uri) {
+        Some(text) => {
+            let line_conts = match text.lines().nth(line) {
+                Some(conts) => conts,
+                None => {
+                    return Err(anyhow::anyhow!(
+                        "get_word_from_pos_params Failed to get word under cursor"
+                    ));
+                }
+            };
+            let (start, end) = find_word_at_pos(line_conts, col);
+            Ok(String::from(&line_conts[start..end]))
+        }
+        None => Err(anyhow::anyhow!(
+            "get_word_from_pos_params Failed to get word under cursor"
+        )),
+    }
 }

--- a/lsp/src/tree_sitter.rs
+++ b/lsp/src/tree_sitter.rs
@@ -106,7 +106,7 @@ pub fn get_position_from_lsp_completion(
     text_params: TextDocumentPositionParams,
 ) -> Option<Position> {
     error!("get_position_from_lsp_completion");
-    let text = get_text_document(text_params.text_document.uri)?;
+    let text = get_text_document(&text_params.text_document.uri)?;
     error!("get_position_from_lsp_completion: text {}", text);
     let pos = text_params.position;
     error!("get_position_from_lsp_completion: pos {:?}", pos);


### PR DESCRIPTION
Hi! I was trying the project out of the test file and initially thought hover support wasn't implemented because I couldn't get a hover window on `hx-target` in the file's initial state. I then changed the hover support implementation before realizing that I just needed to provide a value for `hx-target` and close off the div. 

This PR allows for hover functionality even when a div isn't closed off (and thus even when tree-sitter's CST of the buffer contains some errors near the cursor), as in the initial state of the test file. If this behavior isn't desired, I completely understand :). I'm still familiarizing myself with the codebase, so if I unwittingly made any goofy decisions I'm happy to fix/ refactor things as needed. Some demos:

Before:

![htmxhoverbefore](https://github.com/ThePrimeagen/htmx-lsp/assets/87077023/1cec7dbf-8470-4bfd-9960-55bd034d2116)

After:

![htmxhoverafter](https://github.com/ThePrimeagen/htmx-lsp/assets/87077023/f351d83c-aff9-4792-b527-fd4105fcb6b9)