### PR TITLE
[Fix] Rename JSPerfLspConfig to HtmxLspConfig

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,12 +7,12 @@ use clap::Parser;
 use log::trace;
 use structured_logger::{json::new_writer, Builder};
 
-use opts::JSPerfLspConfig;
+use opts::HtmxLspConfig;
 
 use htmx_lsp_server::start_lsp;
 
 fn main() -> Result<()> {
-    let config = JSPerfLspConfig::parse();
+    let config = HtmxLspConfig::parse();
 
     let mut builder = Builder::with_level(&config.level);
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "waxwing-lsp")]
-pub struct JSPerfLspConfig {
+#[clap()]
+pub struct HtmxLspConfig {
     /// The file to pipe logs out to
     #[clap(short, long)]
     pub file: Option<String>,


### PR DESCRIPTION
- JSPerfLspConfig -> HtmxLspConfig
- no need for clap name