### PR TITLE
fix(lsp): send explicit empty response when no results are available

### DIFF
--- a/lsp/src/handle.rs
+++ b/lsp/src/handle.rs
@@ -171,14 +171,14 @@ pub fn handle_request(req: Request) -> Option<HtmxResult> {
 }
 
 pub fn handle_notification(noti: Notification) -> Option<HtmxResult> {
-    return match noti.method.as_str() {
+    match noti.method.as_str() {
         "textDocument/didChange" => handle_didChange(noti),
         "textDocument/didOpen" => handle_didOpen(noti),
         s => {
             debug!("unhandled notification: {:?}", s);
             None
         }
-    };
+    }
 }
 
 pub fn handle_other(msg: Message) -> Option<HtmxResult> {

--- a/lsp/src/lib.rs
+++ b/lsp/src/lib.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 fn to_completion_list(items: Vec<HxCompletion>) -> CompletionList {
-    return CompletionList {
+    CompletionList {
         is_incomplete: true,
         items: items
             .iter()
@@ -46,7 +46,7 @@ fn to_completion_list(items: Vec<HxCompletion>) -> CompletionList {
                 tags: None,
             })
             .collect(),
-    };
+    }
 }
 
 fn main_loop(connection: Connection, params: serde_json::Value) -> Result<()> {
@@ -68,7 +68,7 @@ fn main_loop(connection: Connection, params: serde_json::Value) -> Result<()> {
 
         match match result {
             Some(HtmxResult::AttributeCompletion(c)) => {
-                let str = match serde_json::to_value(&to_completion_list(c.items)) {
+                let str = match serde_json::to_value(to_completion_list(c.items)) {
                     Ok(s) => s,
                     Err(_) => continue,
                 };

--- a/lsp/src/tree_sitter.rs
+++ b/lsp/src/tree_sitter.rs
@@ -16,10 +16,9 @@ pub enum Position {
 // TODO: remove if not used
 #[allow(dead_code)]
 fn get_text(node: Node<'_>, source: &str) -> String {
-    return node
-        .utf8_text(source.as_bytes())
+    node.utf8_text(source.as_bytes())
         .expect("getting text should never fail")
-        .to_string();
+        .to_string()
 }
 
 // TODO: remove if not used
@@ -71,7 +70,7 @@ fn find_element_referent_to_current_node(node: Node<'_>) -> Option<Node<'_>> {
         return Some(node);
     }
 
-    return find_element_referent_to_current_node(node.parent()?);
+    find_element_referent_to_current_node(node.parent()?)
 }
 
 fn query_position(root: Node<'_>, source: &str, trigger_point: Point) -> Option<Position> {
@@ -122,7 +121,7 @@ pub fn get_position_from_lsp_completion(
     let root_node = tree.root_node();
     let trigger_point = Point::new(pos.line as usize, pos.character as usize);
 
-    return query_position(root_node, text.as_str(), trigger_point);
+    query_position(root_node, text.as_str(), trigger_point)
 }
 
 #[cfg(test)]

--- a/lsp/src/tree_sitter_querier.rs
+++ b/lsp/src/tree_sitter_querier.rs
@@ -95,7 +95,7 @@ pub fn query_attr_keys_for_completion(
     let props = query_props(query_string, node, source, trigger_point);
     let attr_name = props.get("attr_name")?;
 
-    if props.get("unfinished_tag").is_some() {
+    if props.contains_key("unfinished_tag") {
         return None;
     }
 
@@ -159,7 +159,7 @@ pub fn query_attr_values_for_completion(
 
     debug!("query_attr_values_for_completion attr_name {:?}", attr_name);
 
-    if props.get("open_quote_error").is_some() || props.get("empty_attribute").is_some() {
+    if props.contains_key("open_quote_error") || props.contains_key("empty_attribute") {
         return Some(Position::AttributeValue {
             name: attr_name.value.to_owned(),
             value: "".to_string(),


### PR DESCRIPTION
Sending `None` back to Neovim's client seems to play nicer when multiple servers are connected.

I added in some special casing for Helix's client, as there are [issues](https://github.com/bergercookie/asm-lsp/pull/150) with its handling of said messages. I checked the  [current implementation](https://github.com/helix-editor/helix/blob/0815b52e0959e21ec792ea41d508a050b552f850/helix-lsp/src/jsonrpc.rs#L287-L295) and it looks like their response object still doesn't allow for `result` to be `None`.

Closes #53 