### PR TITLE
Implemented quote completions for attribute names

### DIFF
--- a/lsp/src/handle.rs
+++ b/lsp/src/handle.rs
@@ -236,7 +236,7 @@ mod tests {
                 assert!(h.value.starts_with("hx-target"));
             }
             _ => {
-                panic!("unexpected result: {:?}", result);
+                panic!("unexpected result: {result:?}");
             }
         }
     }
@@ -271,7 +271,7 @@ mod tests {
                 assert!(h.value.starts_with("hx-target"));
             }
             _ => {
-                panic!("unexpected result: {:?}", result);
+                panic!("unexpected result: {result:?}");
             }
         }
     }

--- a/lsp/src/handle.rs
+++ b/lsp/src/handle.rs
@@ -1,5 +1,5 @@
 use crate::{
-    htmx::{hx_completion, hx_hover, HxCompletion},
+    htmx::{hx_completion, hx_hover, HxCompletionValue},
     text_store::TEXT_STORE,
 };
 use log::{debug, error, warn};
@@ -40,7 +40,7 @@ struct TextDocumentOpen {
 
 #[derive(Debug)]
 pub struct HtmxAttributeCompletion {
-    pub items: Vec<HxCompletion>,
+    pub items: HxCompletionValue,
     pub id: RequestId,
 }
 
@@ -129,7 +129,7 @@ fn handle_completion(req: Request) -> Option<HtmxResult> {
             );
 
             Some(HtmxResult::AttributeCompletion(HtmxAttributeCompletion {
-                items: items.to_vec(),
+                items,
                 id: req.id,
             }))
         }

--- a/lsp/src/htmx/mod.rs
+++ b/lsp/src/htmx/mod.rs
@@ -10,6 +10,12 @@ pub struct HxCompletion {
     pub desc: &'static str,
 }
 
+#[derive(Clone, Debug)]
+pub enum HxCompletionValue {
+    AttributeName(&'static [HxCompletion]),
+    AttributeValue(&'static [HxCompletion]),
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct HxHover {
     pub name: String,
@@ -27,14 +33,18 @@ macro_rules! build_completion {
     };
 }
 
-pub fn hx_completion(text_params: TextDocumentPositionParams) -> Option<&'static [HxCompletion]> {
+pub fn hx_completion(text_params: TextDocumentPositionParams) -> Option<HxCompletionValue> {
     let result = crate::tree_sitter::get_position_from_lsp_completion(text_params.clone())?;
 
     debug!("result: {:?} params: {:?}", result, text_params);
 
     match result {
-        Position::AttributeName(name) => name.starts_with("hx-").then_some(HX_TAGS),
-        Position::AttributeValue { name, .. } => HX_ATTRIBUTE_VALUES.get(&name).copied(),
+        Position::AttributeName(name) => Some(HxCompletionValue::AttributeName(
+            name.starts_with("hx-").then_some(HX_TAGS)?,
+        )),
+        Position::AttributeValue { name, .. } => Some(HxCompletionValue::AttributeValue(
+            HX_ATTRIBUTE_VALUES.get(&name).copied()?,
+        )),
     }
 }
 

--- a/lsp/src/lib.rs
+++ b/lsp/src/lib.rs
@@ -8,9 +8,9 @@ use anyhow::Result;
 use htmx::HxCompletion;
 use log::{debug, error, info, warn};
 use lsp_types::{
-    ClientInfo, CompletionItem, CompletionItemKind, CompletionList, HoverContents,
-    InitializeParams, MarkupContent, ServerCapabilities, TextDocumentSyncCapability,
-    TextDocumentSyncKind, WorkDoneProgressOptions,
+    ClientInfo, Command, CompletionItem, CompletionItemKind, CompletionList, HoverContents,
+    InitializeParams, InsertTextFormat, MarkupContent, ServerCapabilities,
+    TextDocumentSyncCapability, TextDocumentSyncKind, WorkDoneProgressOptions,
 };
 
 use lsp_server::{Connection, Message, Response};
@@ -25,25 +25,33 @@ fn to_completion_list(items: Vec<HxCompletion>) -> CompletionList {
         is_incomplete: true,
         items: items
             .iter()
-            .map(|x| CompletionItem {
-                label: x.name.to_string(),
-                label_details: None,
-                kind: Some(CompletionItemKind::PROPERTY),
-                detail: Some(x.desc.to_string()),
-                documentation: None,
-                deprecated: Some(false),
-                preselect: None,
-                sort_text: None,
-                filter_text: None,
-                insert_text: None,
-                insert_text_format: None,
-                insert_text_mode: None,
-                text_edit: None,
-                additional_text_edits: None,
-                command: None,
-                commit_characters: None,
-                data: None,
-                tags: None,
+            .map(|x| {
+                let insert = x.name.to_string() + "=\"$1\"";
+
+                CompletionItem {
+                    label: x.name.to_string(),
+                    label_details: None,
+                    kind: Some(CompletionItemKind::PROPERTY),
+                    detail: Some(x.desc.to_string()),
+                    documentation: None,
+                    deprecated: Some(false),
+                    preselect: None,
+                    sort_text: None,
+                    filter_text: None,
+                    insert_text: Some(insert),
+                    insert_text_format: Some(InsertTextFormat::SNIPPET),
+                    insert_text_mode: None,
+                    text_edit: None,
+                    additional_text_edits: None,
+                    command: Some(Command {
+                        title: String::from("Suggest"),
+                        command: "editor.action.triggerSuggest".to_string(),
+                        arguments: None,
+                    }),
+                    commit_characters: None,
+                    data: None,
+                    tags: None,
+                }
             })
             .collect(),
     }

--- a/lsp/src/lib.rs
+++ b/lsp/src/lib.rs
@@ -5,7 +5,7 @@ mod tree_sitter;
 mod tree_sitter_querier;
 
 use anyhow::Result;
-use htmx::HxCompletion;
+use htmx::HxCompletionValue;
 use log::{debug, error, info, warn};
 use lsp_types::{
     ClientInfo, Command, CompletionItem, CompletionItemKind, CompletionList, HoverContents,
@@ -20,40 +20,42 @@ use crate::{
     text_store::init_text_store,
 };
 
-fn to_completion_list(items: Vec<HxCompletion>) -> CompletionList {
-    CompletionList {
-        is_incomplete: true,
-        items: items
-            .iter()
-            .map(|x| {
-                let insert = x.name.to_string() + "=\"$1\"";
-
-                CompletionItem {
+fn to_completion_list(items: HxCompletionValue) -> CompletionList {
+    match items {
+        HxCompletionValue::AttributeName(items) => CompletionList {
+            is_incomplete: true,
+            items: items
+                .to_vec()
+                .iter()
+                .map(|x| CompletionItem {
                     label: x.name.to_string(),
-                    label_details: None,
-                    kind: Some(CompletionItemKind::PROPERTY),
+                    kind: Some(CompletionItemKind::VALUE),
                     detail: Some(x.desc.to_string()),
-                    documentation: None,
-                    deprecated: Some(false),
-                    preselect: None,
-                    sort_text: None,
-                    filter_text: None,
-                    insert_text: Some(insert),
+                    // TODO: Figure out if we can use edit_text instead of insert_text here
+                    insert_text: Some(x.name.to_string() + "=\"$1\""),
                     insert_text_format: Some(InsertTextFormat::SNIPPET),
-                    insert_text_mode: None,
-                    text_edit: None,
-                    additional_text_edits: None,
                     command: Some(Command {
                         title: String::from("Suggest"),
                         command: "editor.action.triggerSuggest".to_string(),
                         arguments: None,
                     }),
-                    commit_characters: None,
-                    data: None,
-                    tags: None,
-                }
-            })
-            .collect(),
+                    ..Default::default()
+                })
+                .collect(),
+        },
+        HxCompletionValue::AttributeValue(items) => CompletionList {
+            is_incomplete: true,
+            items: items
+                .to_vec()
+                .iter()
+                .map(|x| CompletionItem {
+                    label: x.name.to_string(),
+                    kind: Some(CompletionItemKind::PROPERTY),
+                    detail: Some(x.desc.to_string()),
+                    ..Default::default()
+                })
+                .collect(),
+        },
     }
 }
 

--- a/lsp/src/text_store.rs
+++ b/lsp/src/text_store.rs
@@ -42,7 +42,7 @@ pub fn get_text_document(uri: &Url) -> Option<String> {
 /// Find the start and end indices of a word inside the given line
 /// Borrowed from RLS
 fn find_word_at_pos(line: &str, col: usize) -> (usize, usize) {
-    let line_ = format!("{} ", line);
+    let line_ = line.to_string();
     let is_ident_char = |c: char| c.is_alphanumeric() || c == '_' || c == '-';
 
     let start = line_


### PR DESCRIPTION
Previously, the LSP didn't really distinguish between attribute names and values. By adding a new `HxCompletionValue` enum and bubbling the type of the completion up, we can then pattern match on the list of items sent before making the completions list. 

With this change, we can now send two different kinds of completion lists, depending on whether the LSP is autocompleting the **name** or the **value** of the attribute, and so we can edit the completions accordingly:

- Now, attribute name completions are the `Value` kind, just like normal HTML attributes.
- Attribute name completions are now implemented as a `Snippet`, instantly completing with double quotes, again, just like default behavior on HTML attributes. Afterwards, they start autocompleting attribute values immediately.
- Attribute value completions behave exactly the same as before.

This is literally the first time I'm writing Rust so feel free to review as much as you want! However, this PR passes all tests and works at least locally with both `blink.cmp` and `nvim.cmp` on my machine so that's something at least.