### PR TITLE
fix: misc cleanup

### DIFF
--- a/lsp/src/handle.rs
+++ b/lsp/src/handle.rs
@@ -1,5 +1,5 @@
 use crate::{
-    htmx::{hx_completion, hx_hover, HxCompletion},
+    htmx::{hx_completion, hx_hover, HxDocItem},
     text_store::TEXT_STORE,
 };
 use log::{debug, error, warn};
@@ -40,7 +40,7 @@ struct TextDocumentOpen {
 
 #[derive(Debug)]
 pub struct HtmxAttributeCompletion {
-    pub items: Vec<HxCompletion>,
+    pub items: Vec<HxDocItem>,
     pub id: RequestId,
 }
 

--- a/lsp/src/htmx/mod.rs
+++ b/lsp/src/htmx/mod.rs
@@ -5,21 +5,15 @@ use serde::{Deserialize, Serialize};
 use crate::{text_store::get_word_from_pos_params, tree_sitter::Position};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct HxCompletion {
+pub struct HxDocItem {
     pub name: &'static str,
     pub desc: &'static str,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct HxHover {
-    pub name: String,
-    pub desc: String,
 }
 
 macro_rules! build_completion {
     ($(($name:expr, $desc:expr)),*) => {
         &[
-            $(HxCompletion {
+            $(HxDocItem {
             name: $name,
             desc: include_str!($desc),
             }),*
@@ -27,7 +21,7 @@ macro_rules! build_completion {
     };
 }
 
-pub fn hx_completion(text_params: TextDocumentPositionParams) -> Option<&'static [HxCompletion]> {
+pub fn hx_completion(text_params: TextDocumentPositionParams) -> Option<&'static [HxDocItem]> {
     let result = crate::tree_sitter::get_position_from_lsp_completion(text_params.clone())?;
 
     debug!("result: {:?} params: {:?}", result, text_params);
@@ -38,7 +32,7 @@ pub fn hx_completion(text_params: TextDocumentPositionParams) -> Option<&'static
     }
 }
 
-pub fn hx_hover(text_params: TextDocumentPositionParams) -> Option<HxCompletion> {
+pub fn hx_hover(text_params: TextDocumentPositionParams) -> Option<HxDocItem> {
     let result = match get_word_from_pos_params(&text_params) {
         Ok(word) => Position::AttributeName(word),
         Err(_) => {
@@ -54,7 +48,7 @@ pub fn hx_hover(text_params: TextDocumentPositionParams) -> Option<HxCompletion>
     }
 }
 
-pub static HX_TAGS: &[HxCompletion] = build_completion!(
+pub static HX_TAGS: &[HxDocItem] = build_completion!(
     ("hx-boost", "./attributes/hx-boost.md"),
     ("hx-delete", "./attributes/hx-delete.md"),
     ("hx-get", "./attributes/hx-get.md"),
@@ -89,7 +83,7 @@ pub static HX_TAGS: &[HxCompletion] = build_completion!(
     ("hx-validate", "./attributes/hx-validate.md")
 );
 
-pub static HX_ATTRIBUTE_VALUES: phf::Map<&'static str, &[HxCompletion]> = phf::phf_map! {
+pub static HX_ATTRIBUTE_VALUES: phf::Map<&'static str, &[HxDocItem]> = phf::phf_map! {
     "hx-swap" =>
         build_completion![
         ("innerHTML", "./hx-swap/innerHTML.md"),

--- a/lsp/src/lib.rs
+++ b/lsp/src/lib.rs
@@ -5,7 +5,7 @@ mod tree_sitter;
 mod tree_sitter_querier;
 
 use anyhow::Result;
-use htmx::HxCompletion;
+use htmx::HxDocItem;
 use log::{debug, error, info, warn};
 use lsp_types::{
     ClientInfo, CompletionItem, CompletionItemKind, CompletionList, HoverContents,
@@ -20,7 +20,7 @@ use crate::{
     text_store::init_text_store,
 };
 
-fn to_completion_list(items: Vec<HxCompletion>) -> CompletionList {
+fn to_completion_list(items: Vec<HxDocItem>) -> CompletionList {
     CompletionList {
         is_incomplete: true,
         items: items

--- a/lsp/src/text_store.rs
+++ b/lsp/src/text_store.rs
@@ -42,7 +42,7 @@ pub fn get_text_document(uri: &Url) -> Option<String> {
 /// Find the start and end indices of a word inside the given line
 /// Borrowed from RLS
 fn find_word_at_pos(line: &str, col: usize) -> (usize, usize) {
-    let line_ = format!("{} ", line);
+    let line_ = format!("{line} ");
     let is_ident_char = |c: char| c.is_alphanumeric() || c == '_' || c == '-';
 
     let start = line_


### PR DESCRIPTION
- Delete the unused `HxHover` struct. As `HxCompletion` is used for both completion and hover results, rename it to `HxDocItem` to aid readability.
- Appease clippy (The red X for [this](https://github.com/ThePrimeagen/htmx-lsp/actions/runs/16792304740/job/47556170201) CI failure makes me sad)
- Report an error before exiting if the log file can't be opened. This should help any users who run into #50.