### PR TITLE
feat: switch to gen-lsp-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,12 +229,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.0"
+name = "gen-lsp-types"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "b4552cb20fa322e0ebc35c2bbbe3eed8ace907bbcedc92aace7a325c9064b80b"
 dependencies = [
- "percent-encoding",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -275,10 +276,10 @@ name = "htmx-lsp-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "gen-lsp-types",
  "htmx-lsp-util",
  "log",
  "lsp-server",
- "lsp-types",
  "maplit",
  "phf",
  "serde",
@@ -292,19 +293,9 @@ dependencies = [
 name = "htmx-lsp-util"
 version = "0.1.0"
 dependencies = [
+ "gen-lsp-types",
  "log",
- "lsp-types",
  "structured-logger",
-]
-
-[[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -369,19 +360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lsp-types"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b63735a13a1f9cd4f4835223d828ed9c2e35c8c5e61837774399f558b6a1237"
-dependencies = [
- "bitflags 1.3.2",
- "serde",
- "serde_json",
- "serde_repr",
- "url",
-]
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,12 +419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
-
-[[package]]
 name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,18 +468,18 @@ checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -607,18 +579,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.175"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d25439cd7397d044e2748a6fe2432b5e85db703d6d097bd014b3c0ad1ebff0b"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.175"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23f7ade6f110613c0d63858ddb8b94c1041f550eab58a16b371bdf2c9c80ab4"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -636,24 +618,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
- "ryu",
+ "memchr",
  "serde",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e168eaaf71e8f9bd6037feb05190485708e019f4fd87d161b3c0a0d37daf85e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -757,29 +730,14 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -815,37 +773,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "url"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
 
 [[package]]
 name = "utf8parse"
@@ -995,3 +926,9 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ anyhow = "1.0.72"
 clap = { version = "4.3.17", features = ["derive", "env"] }
 log = { version = "0.4.19", features = ["kv_unstable", "kv_unstable_serde"] }
 lsp-server = "0.7.2"
-lsp-types = "0.94.0"
+lsp-types = { package = "gen-lsp-types", version = "0.5.0" }
 serde = { version = "1.0.173", features = ["derive"] }
 serde_json = "1.0.103"
 structured-logger = "1.0.1"

--- a/lsp/src/handle.rs
+++ b/lsp/src/handle.rs
@@ -108,14 +108,14 @@ fn handle_completion(req: Request) -> Option<HtmxResult> {
 
     match completion.context {
         Some(CompletionContext {
-            trigger_kind: CompletionTriggerKind::TRIGGER_CHARACTER,
+            trigger_kind: CompletionTriggerKind::TriggerCharacter,
             ..
         })
         | Some(CompletionContext {
-            trigger_kind: CompletionTriggerKind::INVOKED,
+            trigger_kind: CompletionTriggerKind::Invoked,
             ..
         }) => {
-            let items = match hx_completion(completion.text_document_position) {
+            let items = match hx_completion(completion.text_document_position_params) {
                 Some(items) => items,
                 None => {
                     error!("EMPTY RESULTS OF COMPLETION");

--- a/lsp/src/lib.rs
+++ b/lsp/src/lib.rs
@@ -8,9 +8,9 @@ use anyhow::Result;
 use htmx::HxCompletionValue;
 use log::{debug, error, info, warn};
 use lsp_types::{
-    Command, CompletionItem, CompletionItemKind, CompletionList, HoverContents, InitializeParams,
-    InsertTextFormat, MarkupContent, ServerCapabilities, TextDocumentSyncCapability,
-    TextDocumentSyncKind, WorkDoneProgressOptions,
+    Command, CompletionItem, CompletionItemKind, CompletionList, Contents, InitializeParams,
+    InsertTextFormat, MarkupContent, ServerCapabilities, TextDocumentSyncKind,
+    WorkDoneProgressOptions,
 };
 
 use lsp_server::{Connection, Message, Response};
@@ -29,19 +29,22 @@ fn to_completion_list(items: HxCompletionValue) -> CompletionList {
                 .iter()
                 .map(|x| CompletionItem {
                     label: x.name.to_string(),
-                    kind: Some(CompletionItemKind::VALUE),
+                    kind: Some(CompletionItemKind::Value),
                     detail: Some(x.desc.to_string()),
                     // TODO: Figure out if we can use edit_text instead of insert_text here
                     insert_text: Some(x.name.to_string() + "=\"$1\""),
-                    insert_text_format: Some(InsertTextFormat::SNIPPET),
+                    insert_text_format: Some(InsertTextFormat::Snippet),
                     command: Some(Command {
                         title: String::from("Suggest"),
                         command: "editor.action.triggerSuggest".to_string(),
                         arguments: None,
+                        tooltip: None,
                     }),
                     ..Default::default()
                 })
                 .collect(),
+            apply_kind: None,
+            item_defaults: None,
         },
         HxCompletionValue::AttributeValue(items) => CompletionList {
             is_incomplete: true,
@@ -50,11 +53,13 @@ fn to_completion_list(items: HxCompletionValue) -> CompletionList {
                 .iter()
                 .map(|x| CompletionItem {
                     label: x.name.to_string(),
-                    kind: Some(CompletionItemKind::PROPERTY),
+                    kind: Some(CompletionItemKind::Property),
                     detail: Some(x.desc.to_string()),
                     ..Default::default()
                 })
                 .collect(),
+            apply_kind: None,
+            item_defaults: None,
         },
     }
 }
@@ -94,7 +99,7 @@ fn main_loop(connection: Connection, params: serde_json::Value) -> Result<()> {
             Some(HtmxResult::AttributeHover(hover_resp)) => {
                 debug!("main_loop - hover response: {:?}", hover_resp);
                 let hover_response = lsp_types::Hover {
-                    contents: HoverContents::Markup(MarkupContent {
+                    contents: Contents::MarkupContent(MarkupContent {
                         kind: lsp_types::MarkupKind::Markdown,
                         value: hover_resp.value.to_string(),
                     }),
@@ -153,7 +158,7 @@ pub fn start_lsp() -> Result<()> {
 
     // Run the server and wait for the two threads to end (typically by trigger LSP Exit event).
     let server_capabilities = serde_json::to_value(ServerCapabilities {
-        text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+        text_document_sync: Some(TextDocumentSyncKind::Full.into()),
         completion_provider: Some(lsp_types::CompletionOptions {
             resolve_provider: Some(false),
             trigger_characters: Some(vec!["-".to_string(), "\"".to_string(), " ".to_string()]),
@@ -164,7 +169,7 @@ pub fn start_lsp() -> Result<()> {
             completion_item: None,
         }),
 
-        hover_provider: Some(lsp_types::HoverProviderCapability::Simple(true)),
+        hover_provider: Some(true.into()),
 
         ..Default::default()
     })

--- a/lsp/src/text_store.rs
+++ b/lsp/src/text_store.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex, OnceLock},
 };
 
-use lsp_types::{TextDocumentPositionParams, Url};
+use lsp_types::{TextDocumentPositionParams, Uri};
 
 type TxtStore = HashMap<String, String>;
 
@@ -29,7 +29,7 @@ pub fn init_text_store() {
     _ = TEXT_STORE.set(Arc::new(Mutex::new(TextStore(HashMap::new()))));
 }
 
-pub fn get_text_document(uri: &Url) -> Option<String> {
+pub fn get_text_document(uri: &Uri) -> Option<String> {
     return TEXT_STORE
         .get()
         .expect("text store not initialized")

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -10,4 +10,4 @@ license = "MIT"
 [dependencies]
 log.workspace = true
 structured-logger.workspace = true
-lsp-types = "0.94.0"
+lsp-types.workspace = true


### PR DESCRIPTION
[gen-lsp-types](https://github.com/ribru17/gen-lsp-types) is an alternative to the lsp-types crate, with types generated via codegen from the official LSP Metamodel for correctness and completeness.

lsp-types issues fixed in gen-lsp-types:

- https://github.com/gluon-lang/lsp-types/issues/310
- https://github.com/gluon-lang/lsp-types/issues/308
- https://github.com/gluon-lang/lsp-types/issues/284
- https://github.com/gluon-lang/lsp-types/issues/278
- https://github.com/gluon-lang/lsp-types/issues/277
- https://github.com/gluon-lang/lsp-types/issues/260
- https://github.com/gluon-lang/lsp-types/issues/245
- https://github.com/gluon-lang/lsp-types/issues/93

See https://github.com/rust-lang/rust-analyzer/pull/22115 and https://github.com/wgsl-analyzer/wgsl-analyzer/pull/1090 for other migration considerations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps the core LSP type definitions used across the server, which can subtly change JSON serialization/deserialization and capability wiring. Main risk is client-facing protocol incompatibilities if any renamed fields/enum variants don’t match expectations.
> 
> **Overview**
> Switches the workspace’s `lsp-types` dependency to `gen-lsp-types` and updates both `lsp` and `util` crates to consume it via workspace dependencies.
> 
> Adjusts LSP handling code to the new generated type shapes (renamed enum variants, `text_document_position_params` field, `Url`→`Uri`, hover `contents` type, and capability construction), and updates `Cargo.lock` with the new crate and transitive dependency/version changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 729d66613a4765e238d7afca6d2915814e2ff01a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->